### PR TITLE
FreeBSD/Clang required headers

### DIFF
--- a/src/cql/internal/cql_serialization.cpp
+++ b/src/cql/internal/cql_serialization.cpp
@@ -27,6 +27,8 @@
 #include <string.h> // For memset and memcpy.
 #else
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
 #endif
 
 #include <boost/foreach.hpp>


### PR DESCRIPTION
These are undefined when building cpp-driver on Clang/FreeBSD: AF_INET, in6_addr, AF_INET6.

So, these headers are required in order to build cpp-drvier successfully: netinet/in.h, sys/socket.h

The error output:

/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:636:22: error: 
      use of undeclared identifier 'AF_INET'
    return inet_ntop(AF_INET, src, dst, cnt);
                     ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:657:22: error: 
      use of undeclared identifier 'AF_INET6'
    return inet_ntop(AF_INET6, src, dst, cnt);
                     ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:688:52: error: 
      unknown type name 'in6_addr'; did you mean 'in_addr'?
    BOOST_MPL_ASSERT_RELATION( boost::mpl::sizeof_<in6_addr>::value, ==, 16 );
                                                   ^
/usr/local/include/boost/mpl/assert.hpp:368:60: note: expanded from macro
      'BOOST_MPL_ASSERT_RELATION'
BOOST_MPL_ASSERT_RELATION_IMPL(BOOST_MPL_AUX_PP_COUNTER(), x, rel, y) \
                                                           ^
/usr/local/include/boost/mpl/assert.hpp:328:54: note: expanded from macro '\
BOOST_MPL_ASSERT_RELATION_IMPL'
enum { BOOST_PP_CAT(mpl_assert_rel_value,counter) = (x rel y) }; \
                                                     ^
/usr/include/arpa/inet.h:109:8: note: 'in_addr' declared here
struct in_addr {
       ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:688:52: error: 
      unknown type name 'in6_addr'; did you mean 'in_addr'?
    BOOST_MPL_ASSERT_RELATION( boost::mpl::sizeof_<in6_addr>::value, ==, 16 );
                                                   ^
/usr/local/include/boost/mpl/assert.hpp:368:60: note: expanded from macro
      'BOOST_MPL_ASSERT_RELATION'
BOOST_MPL_ASSERT_RELATION_IMPL(BOOST_MPL_AUX_PP_COUNTER(), x, rel, y) \
                                                           ^
/usr/local/include/boost/mpl/assert.hpp:337:19: note: expanded from macro '\
BOOST_MPL_ASSERT_RELATION_IMPL'
                , x \
                  ^
/usr/local/include/boost/mpl/assert.hpp:59:58: note: expanded from macro '\
BOOST_MPL_AUX_ASSERT_CONSTANT'
# define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) enum { expr }

```
                                                     ^
```

/usr/include/arpa/inet.h:109:8: note: 'in_addr' declared here
struct in_addr {
       ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:688:5: error: 
      no matching function for call to 'assertion_failed'
    BOOST_MPL_ASSERT_RELATION( boost::mpl::sizeof_<in6_addr>::value, ==, 16 );
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/mpl/assert.hpp:367:49: note: expanded from macro
      'BOOST_MPL_ASSERT_RELATION'
# define BOOST_MPL_ASSERT_RELATION(x, rel, y) \

```
                                            ^
```

/usr/local/include/boost/mpl/assert.hpp:332:9: note: expanded from macro '\
BOOST_MPL_ASSERT_RELATION_IMPL'
  ...boost::mpl::assertion_failed<BOOST_PP_CAT(mpl_assert_rel_value,counter)>( \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/mpl/assert.hpp:59:58: note: expanded from macro '\
BOOST_MPL_AUX_ASSERT_CONSTANT'
# define BOOST_MPL_AUX_ASSERT_CONSTANT(T, expr) enum { expr }

```
                                                     ^
```

/usr/local/include/boost/mpl/assert.hpp:82:5: note: candidate function
      [with C = false] not viable: no known conversion from 'boost::mpl::failed
      ***********_(boost::mpl::assert_relation<boost::mpl::assert_::relations(sizeof
      (boost::mpl::assert_::arg == boost::mpl::assert_::arg)),
      boost::mpl::sizeof_<in_addr>::value, 16>::**_******_**)' to 'typename
      assert<false>::type' (aka 'mpl_::assert<false>') for 1st argument
int assertion_failed( typename assert<C>::type );
    ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:711:22: error: 
      use of undeclared identifier 'AF_INET'
    return inet_pton(AF_INET, src, dst);
                     ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:721:22: error: 
      use of undeclared identifier 'AF_INET6'
    return inet_pton(AF_INET6, src, dst);
                     ^
/home/babaei/Desktop/cpp-driver/src/cql/internal/cql_serialization.cpp:740:37: error: 
      unknown type name 'in6_addr'; did you mean 'in_addr'?
    const char buffer_size = sizeof(in6_addr);
                                    ^~~~~~~~
                                    in_addr
/usr/include/arpa/inet.h:109:8: note: 'in_addr' declared here
struct in_addr {
       ^
8 errors generated.
*_\* Error code 1

Stop.
make[2]: stopped in /usr/home/babaei/Desktop/cpp-driver/build
**\* Error code 1

Stop.
make[1]: stopped in /usr/home/babaei/Desktop/cpp-driver/build
**\* Error code 1

Stop.
make: stopped in /usr/home/babaei/Desktop/cpp-driver/build
