### PR TITLE
Fix for prepared statements in multi-node environments

### DIFF
--- a/src/cql/internal/cql_session_impl.cpp
+++ b/src/cql/internal/cql_session_impl.cpp
@@ -454,7 +454,7 @@ cql::cql_session_impl_t::setup_prepared_statements(
         prepare_query->set_stream(*stream);
 
         boost::shared_future<cql::cql_future_result_t> future_result
-            = conn->query(prepare_query);
+            = conn->prepare(prepare_query);
             
         if (future_result.timed_wait(boost::posix_time::seconds(30))) { // TODO: set sensible (or none) time limit
             // The stream was released after receiving the body. Now we need to re-acquire it.


### PR DESCRIPTION
Prepared statements in multi-node environments are failing. After switching the cassandra node, the cpp-driver tries to execute the prepared statement instead of preparing it. As a result, the prepared statement is not available on the cassandra node and the prepared statement can not be executed.

For additional information, see the discussion at the user mailing list: https://groups.google.com/a/lists.datastax.com/forum/#!topic/cpp-driver-user/d0TngHHDIOk
