### PR TITLE
Removed memory leak in refresh_node_list_and_token_map

### DIFF
--- a/src/cql/internal/cql_control_connection.cpp
+++ b/src/cql/internal/cql_control_connection.cpp
@@ -242,6 +242,8 @@ cql_control_connection_t::refresh_node_list_and_token_map()
 							peer_tokens_set->get_string(i, single_peers_token);
 							all_tokens.back()[single_peers_token] = true;
 						}
+						
+						delete peer_tokens_set;
 					}
                 }
             }


### PR DESCRIPTION
The function refresh_node_list_and_token_map contains a memory leak. It calls cql_message_result_impl_t::get_set which allocates new memory. This memory will never be freed. 
# 

Before:

$ valgrind --leak-check=full ./cql_demo --host 192.168.1.108
[...]
THE END
==8093== 
==8093== HEAP SUMMARY:
==8093==     in use at exit: 352 bytes in 12 blocks
==8093==   total heap usage: 5,692 allocs, 5,680 frees, 381,742 bytes allocated
==8093== 
==8093== 256 (224 direct, 32 indirect) bytes in 4 blocks are definitely lost in loss record 6 of 6
==8093==    at 0x4C286E7: operator new(unsigned long) (vg_replace_malloc.c:287)
==8093==    by 0x5C1B978: cql::cql_message_result_impl_t::get_set(int, cql::cql_set_t**) const (cql_message_result_impl.cpp:478)
==8093==    by 0x5C1BA50: cql::cql_message_result_impl_t::get_set(std::string const&, cql::cql_set_t**) const (cql_message_result_impl.cpp:489)
==8093==    by 0x5C1F0F5: cql::cql_control_connection_t::refresh_node_list_and_token_map() (cql_control_connection.cpp:231)
==8093==    by 0x5C21414: cql::cql_control_connection_t::setup_control_connection(bool) (cql_control_connection.cpp:484)
==8093==    by 0x5C1DD79: cql::cql_control_connection_t::init() (cql_control_connection.cpp:85)
==8093==    by 0x5BE07C9: cql::cql_cluster_impl_t::cql_cluster_impl_t(std::list<cql::cql_endpoint_t, std::allocator<cql::cql_endpoint_t> > const&, boost::shared_ptrcql::cql_configuration_t) (cql_cluster_impl.hpp:120)
==8093==    by 0x5BDE8DB: cql::cql_cluster_t::built_from(cql::cql_initializer_t&) (cql_cluster.cpp:36)
==8093==    by 0x5BE7116: cql::cql_builder_t::build() (cql_builder.cpp:93)
==8093==    by 0x42F9AD: demo(std::string const&, bool) (main.cpp:90)
==8093==    by 0x4308B1: main (main.cpp:193)
==8093== 
==8093== LEAK SUMMARY:
==8093==    definitely lost: 224 bytes in 4 blocks
==8093==    indirectly lost: 32 bytes in 4 blocks
==8093==      possibly lost: 0 bytes in 0 blocks
==8093==    still reachable: 96 bytes in 4 blocks
==8093==         suppressed: 0 bytes in 0 blocks
==8093== Reachable blocks (those to which a pointer was found) are not shown.
==8093== To see them, rerun with: --leak-check=full --show-reachable=yes
==8093== 
==8093== For counts of detected and suppressed errors, rerun with: -v
==8093== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 4 from 4)
# 

After:

$ valgrind --leak-check=full ./cql_demo --host 192.168.1.108
[...]
THE END
==8291== 
==8291== HEAP SUMMARY:
==8291==     in use at exit: 96 bytes in 4 blocks
==8291==   total heap usage: 5,694 allocs, 5,690 frees, 381,835 bytes allocated
==8291== 
==8291== LEAK SUMMARY:
==8291==    definitely lost: 0 bytes in 0 blocks
==8291==    indirectly lost: 0 bytes in 0 blocks
==8291==      possibly lost: 0 bytes in 0 blocks
==8291==    still reachable: 96 bytes in 4 blocks
==8291==         suppressed: 0 bytes in 0 blocks
==8291== Reachable blocks (those to which a pointer was found) are not shown.
==8291== To see them, rerun with: --leak-check=full --show-reachable=yes
==8291== 
==8291== For counts of detected and suppressed errors, rerun with: -v
==8291== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 4 from 4)
