### PR TITLE
Change sense of return of cql_message_result::is_null to align with get_* methods

### DIFF
--- a/include/cql/cql_result.hpp
+++ b/include/cql/cql_result.hpp
@@ -85,12 +85,12 @@ public:
               int& output) const = 0;
 
     virtual bool
-    is_null(int i,
-            bool& output) const = 0;
+    get_nullity(int i,
+                bool& output) const = 0;
 
     virtual bool
-    is_null(const std::string& column,
-            bool& output) const = 0;
+    get_nullity(const std::string& column,
+                bool& output) const = 0;
 
     virtual bool
     get_bool(int i,

--- a/include/cql/internal/cql_message_result_impl.hpp
+++ b/include/cql/internal/cql_message_result_impl.hpp
@@ -104,12 +104,12 @@ public:
               int& output) const;
 
     bool
-    is_null(int i,
-            bool& output) const;
+    get_nullity(int i,
+                bool& output) const;
 
     bool
-    is_null(const std::string& column,
-            bool& output) const;
+    get_nullity(const std::string& column,
+                bool& output) const;
 
     bool
     get_bool(int i,
@@ -200,7 +200,7 @@ public:
     is_valid(int i,
              cql::cql_column_type_enum column_type) const {
         bool index_null = false;
-        if (!is_null(i, index_null) || index_null) {
+        if (!get_nullity(i, index_null) || index_null) {
             return false;
         }
 

--- a/src/cql/internal/cql_control_connection.cpp
+++ b/src/cql/internal/cql_control_connection.cpp
@@ -198,7 +198,7 @@ cql_control_connection_t::refresh_node_list_and_token_map()
                 cql_host_t::ip_address_t peer_address;
                 bool output = false;
 
-                if (result->is_null("rpc_address", output) && !output)
+                if (result->get_nullity("rpc_address", output) && !output)
                 {
                     cql::cql_byte_t* data = NULL;
                     cql::cql_int_t size = 0;
@@ -208,7 +208,7 @@ cql_control_connection_t::refresh_node_list_and_token_map()
                 }
                 if (peer_address == ::boost::asio::ip::address())
                 {
-                    if (result->is_null("peer", output) && !output)
+                    if (result->get_nullity("peer", output) && !output)
                     {
                         cql::cql_byte_t* data = NULL;
                         cql::cql_int_t size = 0;

--- a/src/cql/internal/cql_message_result_impl.cpp
+++ b/src/cql/internal/cql_message_result_impl.cpp
@@ -266,7 +266,7 @@ cql::cql_message_result_impl_t::next() {
 }
 
 bool
-cql::cql_message_result_impl_t::is_null(
+cql::cql_message_result_impl_t::get_nullity(
     int   i,
     bool& output) const {
     if (i >= _column_count || i < 0) {
@@ -279,7 +279,7 @@ cql::cql_message_result_impl_t::is_null(
 }
 
 bool
-cql::cql_message_result_impl_t::is_null(
+cql::cql_message_result_impl_t::get_nullity(
     const std::string& column,
     bool&              output) const {
     int i = 0;
@@ -422,7 +422,7 @@ cql::cql_message_result_impl_t::get_data(int i,
         cql::cql_byte_t** output,
         cql::cql_int_t& size) const {
     bool empty = false;
-    if (is_null(i, empty)) {
+    if (get_nullity(i, empty)) {
         if (!empty) {
             cql_byte_t* pos = _row[i];
             *output = cql::decode_int(pos, size);

--- a/test/unit_tests/cql_message_result.cpp
+++ b/test/unit_tests/cql_message_result.cpp
@@ -112,7 +112,7 @@ TEST_MESSAGE_RESULT[] = { 0x00, 0x00, 0x00, 0x02, // result_type(int=2)
                           0xff, 0xff, 0xff, 0xff,
                           0xff, 0xff, 0xff, 0xff,
                           0x00, 0x00, 0x00, 0x00,  // 15
-                          0x00, 0x01, 0xFF, 0xFF}; // this is different that real life, which would be 1 null byte, needed to test the negative is_null case
+                          0x00, 0x01, 0xFF, 0xFF}; // this is different that real life, which would be 1 null byte, needed to test the negative get_nullity case
 
 
 BOOST_AUTO_TEST_CASE(opcode)
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE(not_null)
     BOOST_CHECK_EQUAL(true, m.next());
 
     bool is_null = false;
-    BOOST_CHECK_EQUAL(true, m.is_null(16, is_null));
+    BOOST_CHECK_EQUAL(true, m.get_nullity(16, is_null));
     BOOST_CHECK_EQUAL(false, is_null);
 }
 
@@ -531,7 +531,7 @@ BOOST_AUTO_TEST_CASE(null_columns_map)
     BOOST_CHECK_EQUAL(true, m.next());
 
     bool is_null = false;
-    BOOST_CHECK_EQUAL(true, m.is_null(2, is_null));
+    BOOST_CHECK_EQUAL(true, m.get_nullity(2, is_null));
     BOOST_CHECK_EQUAL(true, is_null);
 
     cql::cql_map_t* map = NULL;
@@ -549,7 +549,7 @@ BOOST_AUTO_TEST_CASE(null_columns_text)
     BOOST_CHECK_EQUAL(true, m.next());
 
     bool is_null = false;
-    BOOST_CHECK_EQUAL(true, m.is_null(11, is_null));
+    BOOST_CHECK_EQUAL(true, m.get_nullity(11, is_null));
     BOOST_CHECK_EQUAL(true, is_null);
 
     std::string val;


### PR DESCRIPTION
It seems that the bool returned by is_null ought to have the same sense as the bool returned by the various get_\* methods.  That is, a "true" should mean that the method completed correctly.  This is how it was a while ago, so this PR restores the original API design.
