### PR TITLE
Changed nullptr to NULL

### DIFF
--- a/src/cql/cql_builder.cpp
+++ b/src/cql/cql_builder.cpp
@@ -113,7 +113,7 @@ cql::cql_builder_t& cql::cql_builder_t::with_load_balancing_policy( boost::share
 	if( load_balancing_policy == NULL )
 		return *this;
 		
-	if( load_balancing_policy == nullptr )
+	if( load_balancing_policy == NULL )
 		return *this;
 
 	_load_balancing_policy = load_balancing_policy;	
@@ -128,7 +128,7 @@ cql::cql_builder_t& cql::cql_builder_t::with_reconnection_policy( boost::shared_
 	if( reconnection_policy == NULL )
 		return *this;
 		
-	if( reconnection_policy == nullptr )
+	if( reconnection_policy == NULL )
 		return *this;
 
 	_reconnection_policy = reconnection_policy;	
@@ -141,7 +141,7 @@ cql::cql_builder_t& cql::cql_builder_t::with_retry_policy( boost::shared_ptr< cq
 	if( retry_policy == NULL )
 		return *this;
 		
-	if( retry_policy == nullptr )
+	if( retry_policy == NULL )
 		return *this;
 
 	_retry_policy = retry_policy;	

--- a/test/integration_tests/src/one_node_balancing.cpp
+++ b/test/integration_tests/src/one_node_balancing.cpp
@@ -51,7 +51,7 @@ cql::cql_one_node_query_plan_t::next_host_to_query()
 	{
 		for( int i = 0; i < _hosts.size(); ++i )
 		{
-			if( _hosts[ i ].get() != nullptr )
+			if( _hosts[ i ].get() != NULL )
 			{							   
 				if( _hosts[ i ].get()->address().to_string() == _hostAddress )
 				{


### PR DESCRIPTION
Pull request 21 introduced the new C++11 keyword 'nullptr'. Building the project now fails on debian 7 with gcc 4.7.2.

Older commits, like 'a78dfba00484f1f534cb70bffd0652456ae49660', are removing all C++11 code and the compiler option '-std=c++0x'. So I changed all occurrences of nullptr to NULL.

```
[  7%] Building CXX object CMakeFiles/cql.dir/src/cql/cql_builder.cpp.o
/usr/bin/c++   -Dcql_EXPORTS -DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB -fPIC -I/home/kristof/api/cpp-driver/include     -fPIC -Wall -pedantic -Wno-long-long -fno-strict-aliasing -o CMakeFiles/cql.dir/src/cql/cql_builder.cpp.o -c /home/kristof/api/cpp-driver/src/cql/cql_builder.cpp
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp:116:2: warning: identifier 'nullptr' is a keyword in C++11 [-Wc++0x-compat]
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp: In member function 'cql::cql_builder_t& cql::cql_builder_t::with_load_balancing_policy(boost::shared_ptr<cql::cql_load_balancing_policy_t>)':
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp:116:31: error: 'nullptr' was not declared in this scope
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp: In member function 'cql::cql_builder_t& cql::cql_builder_t::with_reconnection_policy(boost::shared_ptr<cql::cql_reconnection_policy_t>)':
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp:131:29: error: 'nullptr' was not declared in this scope
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp: In member function 'cql::cql_builder_t& cql::cql_builder_t::with_retry_policy(boost::shared_ptr<cql::cql_retry_policy_t>)':
/home/kristof/api/cpp-driver/src/cql/cql_builder.cpp:144:22: error: 'nullptr' was not declared in this scope
make[3]: *** [CMakeFiles/cql.dir/src/cql/cql_builder.cpp.o] Fehler 1
make[3]: Leaving directory `/home/kristof/api/cpp-driver'
make[2]: *** [CMakeFiles/cql.dir/all] Fehler 2
make[2]: Leaving directory `/home/kristof/api/cpp-driver'
make[1]: *** [all] Fehler 2
make[1]: Leaving directory `/home/kristof/api/cpp-driver'
make: *** [build-stamp] Fehler 2
```
