### PR TITLE
the correction of an error that srand() was called every time instead of...

### DIFF
--- a/src/cql/internal/cql_rand.cpp
+++ b/src/cql/internal/cql_rand.cpp
@@ -25,8 +25,12 @@ cql::cql_rand() {
 	static bool rand_initialized = false;
 
 	boost::lock_guard<boost::detail::spinlock> lock(sl);
+		
 	if(!rand_initialized)
+	{
 		srand((unsigned)time(NULL));
+		rand_initialized = true;	
+	}
 
 	return rand();
 }


### PR DESCRIPTION
... once only at first call.
