### PR TITLE
"skip" method to generate a null value in prepared queries

### DIFF
--- a/include/cql/cql_execute.hpp
+++ b/include/cql/cql_execute.hpp
@@ -83,6 +83,9 @@ public:
 
     void
     push_back(const bool val);
+    
+    void
+    skip();
 
     void
     pop_back();
@@ -111,6 +114,9 @@ public:
             
     void
     set_stream(const cql_stream_t& stream);
+     
+    std::string 
+    str() const;
 
 private:
     boost::shared_ptr<cql_message_execute_impl_t> _impl;

--- a/include/cql/internal/cql_message_execute_impl.hpp
+++ b/include/cql/internal/cql_message_execute_impl.hpp
@@ -81,6 +81,9 @@ public:
 
     void
     push_back(const bool val);
+    
+    void
+    skip();
 
     void
     pop_back();

--- a/include/cql/internal/cql_serialization.hpp
+++ b/include/cql/internal/cql_serialization.hpp
@@ -163,6 +163,12 @@ decode_string(cql::cql_byte_t* input,
 std::ostream&
 encode_bytes(std::ostream& output,
              const std::vector<cql::cql_byte_t>& value);
+             
+std::ostream&
+encode_null_byte(std::ostream& output);
+
+void
+encode_null_byte(std::vector<cql::cql_byte_t>& output);
 
 std::istream&
 decode_bytes(std::istream& input,

--- a/src/cql/cql_execute.cpp
+++ b/src/cql/cql_execute.cpp
@@ -97,6 +97,11 @@ cql::cql_execute_t::push_back(const bool val) {
 }
 
 void
+cql::cql_execute_t::skip() {
+    _impl->skip();
+}
+
+void
 cql::cql_execute_t::pop_back() {
     _impl->pop_back();
 }
@@ -141,6 +146,12 @@ cql::cql_stream_t
 cql::cql_execute_t::stream()
 {
     return impl()->stream();
+}
+
+std::string 
+cql::cql_execute_t::str() const
+{
+    return impl()->str();
 }
 
 void

--- a/src/cql/internal/cql_message_execute_impl.cpp
+++ b/src/cql/internal/cql_message_execute_impl.cpp
@@ -131,6 +131,13 @@ cql::cql_message_execute_impl_t::push_back(const bool val) {
 }
 
 void
+cql::cql_message_execute_impl_t::skip() {
+    cql::cql_message_execute_impl_t::param_t p;
+    cql::encode_null_byte(p);
+    _params.push_back(p);
+}
+
+void
 cql::cql_message_execute_impl_t::pop_back() {
     _params.pop_back();
 }

--- a/src/cql/internal/cql_serialization.cpp
+++ b/src/cql/internal/cql_serialization.cpp
@@ -362,6 +362,23 @@ cql::encode_bytes(ostream& output,
     return output;
 }
 
+ostream&
+cql::encode_null_byte(ostream& output) {
+    // As per CQL bytes representation, if len is negative, no byte
+    //  should follow and the represented value is 'null'
+    cql::cql_int_t len = -1; 
+    output.write(reinterpret_cast<char*>(&len), sizeof(len));
+    return output;
+}
+
+void
+cql::encode_null_byte(vector<cql::cql_byte_t>& output) {
+    cql::cql_byte_t l = -1;
+    output.resize(sizeof(l));
+    const cql::cql_byte_t* it = reinterpret_cast<cql::cql_byte_t*>(&l);
+    output.assign(it, it + sizeof(l));
+}
+
 istream&
 cql::decode_bytes(istream& input,
                   vector<cql::cql_byte_t>& value) {


### PR DESCRIPTION
Hi

as stated in [this discussion](https://groups.google.com/a/lists.datastax.com/forum/#!topic/cpp-driver-user/5-68laqBNPM), I think prepared queries with unnamed variables are very limited.

In my use case, I have a CQL table with many fields and a massive amount of INSERT to perform, where only some fields per query will be present. I want to do this with prepared queries for performance reasons.

At present, prepared queries with '?' bound variables are not usable in real life. Best solution would be to have named bound variables, but I understand this is not immediate to accomplish (also, very new feature in cassandra and CQL).

So, temporarily, I would just love to have a "skip" method that I could use instead of a "push_back" every time I do not have a value to push to a given field.

This is my attempt to implement this. It is based on the following description of a "null" byte in binary protocol specifications. I'm not sure this is the correct way to do it, however it was quick enough to implement that I just tried it

```
    [bytes]        A [int] n, followed by n bytes if n >= 0. If n < 0,
                   no byte should follow and the value represented is `null`.
```

I have tested this with a simple table.

Notice that the entry for key4 is generated manually by a cqlsh query where I just insert a value for v3. I correctly see "null" for v2 field.

key2 and key3 entries are generated by a prepared query using the "skip" method. I don't see the "null" representation so I guess my method is not correct

```
 key  | v2   | v3
------+------+-----
 key1 |    a |  b
 key4 | null |   b
 key3 |    a |
 key2 |      |  b
```

Any pointers about this? Is this even possible at all with my (simple) approach?

Thanks

Giacomo

P.S. i just realized I committed also the exposure of "str()" method from cql_message_execute_impl_t. That is unrelated to the "skip" method
