### PR TITLE
Fix preventing segmentation fault in boost asio

### DIFF
--- a/include/cql/internal/cql_connection_impl.hpp
+++ b/include/cql/internal/cql_connection_impl.hpp
@@ -1064,7 +1064,7 @@ private:
             return;
         }
 
-		boost::asio::async_read(*_transport,
+        boost::asio::async_read(*_transport,
                                 boost::asio::buffer(header.length()==0 ? 0 : _response_message->buffer()->data(), _response_message->size()),
 #if BOOST_VERSION >= 104800
                                 boost::asio::transfer_exactly(header.length()),


### PR DESCRIPTION
The driver's design implies cyclic reading of socket, handling incoming messages. This makes possible closing of a connection while it is doing asynchronous reading from socket. The problem is that boost ASIO library does not support starting of socket  asynchronous operation after the socket itself was closed, causing race condition and possible SEGFAULT (see corresponding ticket https://svn.boost.org/trac/boost/ticket/7611).
- This fix prevents calling async_read if socket was closed.
- Some extra logging added
