### PR TITLE
Lists of ints or strings for prepared statements.

### DIFF
--- a/include/cql/cql_execute.hpp
+++ b/include/cql/cql_execute.hpp
@@ -86,6 +86,12 @@ public:
     push_back(const bool val);
 
     void
+    push_back_list(const std::vector<cql::cql_int_t>& val);
+
+    void
+    push_back_list(const std::vector<std::string>& val);
+
+    void
     push_back_null();
 
     void

--- a/include/cql/internal/cql_message_execute_impl.hpp
+++ b/include/cql/internal/cql_message_execute_impl.hpp
@@ -89,6 +89,12 @@ public:
     push_back(const bool val);
 
     void
+    push_back_list(const std::vector<cql_int_t>& val);
+
+    void
+    push_back_list(const std::vector<std::string>& val);
+
+    void
     push_back_null();
 
     void

--- a/include/cql/internal/cql_serialization.hpp
+++ b/include/cql/internal/cql_serialization.hpp
@@ -52,8 +52,8 @@ encode_short(std::ostream& output,
              cql::cql_short_t value);
 
 void
-encode_short(std::vector<cql::cql_byte_t>& output,
-             const cql::cql_short_t value);
+encode_append_short(std::vector<cql::cql_byte_t>& output,
+                    const cql::cql_short_t value);
 
 std::istream&
 decode_short(std::istream& input,
@@ -71,8 +71,20 @@ encode_int(std::ostream& output,
            const cql::cql_int_t value);
 
 void
-encode_int(std::vector<cql::cql_byte_t>& output,
-           const cql::cql_int_t value);
+encode_append_int(std::vector<cql::cql_byte_t>& output,
+                  const cql::cql_int_t value);
+
+void
+encode_append_string(std::vector<cql::cql_byte_t>& output,
+                     const std::string& value);
+
+void
+encode_int_list(std::vector<cql::cql_byte_t>& output,
+                const std::vector<cql::cql_int_t>& value);
+
+void
+encode_string_list(std::vector<cql::cql_byte_t>& output,
+                   const std::vector<std::string>& value);
 
 std::istream&
 decode_int(std::istream& input,

--- a/src/cql/cql_execute.cpp
+++ b/src/cql/cql_execute.cpp
@@ -98,6 +98,16 @@ cql::cql_execute_t::push_back(const bool val) {
 }
 
 void
+cql::cql_execute_t::push_back_list(const std::vector<cql::cql_int_t>& val) {
+    _impl->push_back_list(val);
+}
+
+void
+cql::cql_execute_t::push_back_list(const std::vector<std::string>& val) {
+    _impl->push_back_list(val);
+}
+
+void
 cql::cql_execute_t::push_back_null() {
     _impl->push_back_null();
 }

--- a/src/cql/internal/cql_message_execute_impl.cpp
+++ b/src/cql/internal/cql_message_execute_impl.cpp
@@ -100,14 +100,14 @@ cql::cql_message_execute_impl_t::push_back(const std::string& val) {
 void
 cql::cql_message_execute_impl_t::push_back(const cql::cql_short_t val) {
     boost::shared_ptr<param_t> p(new param_t);
-    cql::encode_short(*p, val);
+    cql::encode_append_short(*p, val);
     _params.push_back(p);
 }
 
 void
 cql::cql_message_execute_impl_t::push_back(const cql::cql_int_t val) {
     boost::shared_ptr<param_t> p(new param_t);
-    cql::encode_int(*p, val);
+    cql::encode_append_int(*p, val);
     _params.push_back(p);
 }
 
@@ -136,6 +136,20 @@ void
 cql::cql_message_execute_impl_t::push_back(const bool val) {
     boost::shared_ptr<param_t> p(new param_t);
     cql::encode_bool(*p, val);
+    _params.push_back(p);
+}
+
+void
+cql::cql_message_execute_impl_t::push_back_list(const std::vector<cql::cql_int_t>& val) {
+    boost::shared_ptr<param_t> p(new param_t);
+    cql::encode_int_list(*p, val);
+    _params.push_back(p);
+}
+
+void
+cql::cql_message_execute_impl_t::push_back_list(const std::vector<std::string>& val) {
+    boost::shared_ptr<param_t> p(new param_t);
+    cql::encode_string_list(*p, val);
     _params.push_back(p);
 }
 

--- a/src/cql/internal/cql_serialization.cpp
+++ b/src/cql/internal/cql_serialization.cpp
@@ -141,12 +141,11 @@ cql::encode_short(ostream& output,
 }
 
 void
-cql::encode_short(vector<cql::cql_byte_t>& output,
-                  const cql::cql_short_t value) {
+cql::encode_append_short(vector<cql::cql_byte_t>& output,
+                         const cql::cql_short_t value) {
     cql::cql_short_t s = htons(value);
-    output.resize(sizeof(s));
     const cql::cql_byte_t* it = reinterpret_cast<cql::cql_byte_t*>(&s);
-    output.assign(it, it + sizeof(s));
+    output.insert(output.end(), it, it + sizeof(s));
 }
 
 istream&
@@ -178,12 +177,41 @@ cql::encode_int(ostream& output,
 }
 
 void
-cql::encode_int(vector<cql::cql_byte_t>& output,
-                const cql::cql_int_t value) {
+cql::encode_append_int(vector<cql::cql_byte_t>& output,
+                       const cql::cql_int_t value) {
     cql::cql_int_t l = htonl(value);
-    output.resize(sizeof(l));
     const cql::cql_byte_t* it = reinterpret_cast<cql::cql_byte_t*>(&l);
-    output.assign(it, it + sizeof(l));
+    output.insert(output.end(), it, it + sizeof(l));
+}
+
+void
+cql::encode_append_string(vector<cql::cql_byte_t>& output,
+                          const std::string& value) {
+    output.insert(output.end(), value.begin(), value.end());
+}
+
+void
+cql::encode_int_list(vector<cql::cql_byte_t>& output,
+                     const vector<cql::cql_int_t>& value) {
+    size_t to_reserve = sizeof(cql::cql_short_t) +
+        value.size() * (sizeof(cql::cql_short_t) + sizeof(cql::cql_int_t));
+    output.reserve(to_reserve);
+
+    cql::encode_append_short(output, value.size());
+    for (size_t i = 0; i < value.size(); i++){
+        encode_append_short(output, sizeof(cql::cql_int_t));
+        encode_append_int(output, value[i]);
+    }
+}
+
+void
+cql::encode_string_list(vector<cql::cql_byte_t>& output,
+                        const vector<std::string>& value) {
+    cql::encode_append_short(output, value.size());
+    for (size_t i = 0; i < value.size(); i++){
+        encode_append_short(output, value[i].size());
+        encode_append_string(output, value[i]);
+    }
 }
 
 istream&


### PR DESCRIPTION
This edit should enable passing vector&lt;cql_int_t&gt; and vector&lt;std::string&gt; to be bound as prepared query parameters of Cassandra-types list&lt;int&gt; and list&lt;text&gt;.
More list types could be added analogously, although some type generalization would be nice, otherwise there would be lots of almost-multiplication of code for the types and list encoding...
