### PR TITLE
Set up Doxygen to work with the CMake tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ Debug
 demo/cassandra_demo
 test/unit_tests/cassandra_test
 
+# API docs files
+docs
+Doxyfile
+
 # editor
 *.swp
 *~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,3 +190,17 @@ add_subdirectory(examples/collections)
 # the demo program
 #-------------------
 add_subdirectory(demo)
+
+#-----------------------------------
+# generating API docs with Doxygen
+#-----------------------------------
+
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+    add_custom_target(doc
+        ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen" VERBATIM)
+endif(DOXYGEN_FOUND)
+

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -26,13 +26,13 @@ DOXYFILE_ENCODING      = UTF-8
 # identify the project. Note that if you do not use Doxywizard you need
 # to put quotes around the project name if it contains spaces.
 
-PROJECT_NAME           = "cassandra"
+PROJECT_NAME           = "DataStax C/C++ Driver"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number.
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         =
+PROJECT_NUMBER         = 1.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = "build/doc"
+OUTPUT_DIRECTORY       = "docs"
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -327,7 +327,7 @@ INLINE_SIMPLE_STRUCTS  = NO
 # be useful for C code in case the coding convention dictates that all compound
 # types are typedef'ed and only the typedef is referenced, never the tag name.
 
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEDEF_HIDES_STRUCT   = YES
 
 # The SYMBOL_CACHE_SIZE determines the size of the internal cache use to
 # determine which symbols to keep in memory and which to flush to disk.
@@ -342,8 +342,8 @@ TYPEDEF_HIDES_STRUCT   = NO
 # memory usage. The cache size is given by this formula:
 # 2^(16+SYMBOL_CACHE_SIZE). The valid range is 0..9, the default is 0,
 # corresponding to a cache size of 2^16 = 65536 symbols.
-
-SYMBOL_CACHE_SIZE      = 0
+#
+#SYMBOL_CACHE_SIZE      = 0
 
 # Similar to the SYMBOL_CACHE_SIZE the size of the symbol lookup cache can be
 # set using LOOKUP_CACHE_SIZE. This cache is used to resolve symbols given
@@ -365,7 +365,7 @@ LOOKUP_CACHE_SIZE      = 0
 # Private class members and static file members will be hidden unless
 # the EXTRACT_PRIVATE and EXTRACT_STATIC tags are set to YES
 
-EXTRACT_ALL            = NO
+EXTRACT_ALL            = YES
 
 # If the EXTRACT_PRIVATE tag is set to YES all private members of a class
 # will be included in the documentation.
@@ -541,7 +541,7 @@ GENERATE_BUGLIST       = YES
 # disable (NO) the deprecated list. This list is created by putting
 # \deprecated commands in the documentation.
 
-GENERATE_DEPRECATEDLIST= YES
+GENERATE_DEPRECATEDLIST = YES
 
 # The ENABLED_SECTIONS tag can be used to enable conditional
 # documentation sections, marked by \if section-label ... \endif
@@ -668,7 +668,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = include/cassandra
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -686,7 +686,7 @@ INPUT_ENCODING         = UTF-8
 # *.hxx *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.dox *.py
 # *.f90 *.f *.for *.vhd *.vhdl
 
-FILE_PATTERNS          = *.hpp
+FILE_PATTERNS          = *.h *.hpp
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories
 # should be searched for input files as well. Possible values are YES and NO.
@@ -1469,14 +1469,14 @@ XML_OUTPUT             = xml
 # The XML_SCHEMA tag can be used to specify an XML schema,
 # which can be used by a validating XML parser to check the
 # syntax of the XML files.
-
-XML_SCHEMA             =
+#
+#XML_SCHEMA             =
 
 # The XML_DTD tag can be used to specify an XML DTD,
 # which can be used by a validating XML parser to check the
 # syntax of the XML files.
-
-XML_DTD                =
+#
+#XML_DTD                =
 
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will
 # dump the program listings (including syntax highlighting
@@ -1862,3 +1862,4 @@ GENERATE_LEGEND        = YES
 # the various graphs.
 
 DOT_CLEANUP            = YES
+

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -37,6 +37,13 @@
 #   endif
 #endif
 
+/**
+ * @file include/cassandra.h
+ *
+ * TBD.
+ */
+
+
 /* TODO(mpenick) handle primitive types for other compilers and platforms */
 
 #define cass_false 0
@@ -208,9 +215,9 @@ CASS_EXPORT void
 cass_session_free(CassSession* session);
 
 /**
- * Set an option on the specified session
+ * Set an option on the specified session.
  *
- * @param cluster
+ * @param session
  * @param option
  * @param data
  * @param data_length
@@ -220,11 +227,13 @@ cass_session_free(CassSession* session);
 CASS_EXPORT CassError
 cass_session_setopt(CassSession* session,
                     CassOption option,
-                    const void* data, cass_size_t data_length);
+                    const void* data, 
+                    cass_size_t data_length);
 
 /**
- * Get the option value for the specified session
+ * Get the option value for the specified session.
  *
+ * @param session
  * @param option
  * @param data
  * @param data_length
@@ -234,11 +243,12 @@ cass_session_setopt(CassSession* session,
 CASS_EXPORT CassError
 cass_session_getopt(const CassSession* session,
                     CassOption option,
-                    void** data, cass_size_t* data_length);
+                    void** data, 
+                    cass_size_t* data_length);
 
 /**
  * Shutdown the session instance, output a shutdown future which can
- * be used to determine when the session has been terminated
+ * be used to determine when the session has been terminated.
  *
  * @param session
  */
@@ -249,8 +259,7 @@ cass_session_shutdown(CassSession* session);
  * Initiate a session using the specified session. Resulting
  * future must be freed by caller.
  *
- * @param cluster
- * @param future output future, must be freed by caller, pass NULL to avoid allocation
+ * @param session
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -263,7 +272,6 @@ cass_session_connect(CassSession* session);
  *
  * @param session
  * @param keyspace
- * @param future output future, must be freed by caller, pass NULL to avoid allocation
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -276,8 +284,6 @@ cass_session_connect_keyspace(CassSession* session,
  *
  * @param session
  * @param statement string
- * @param statement_length statement string length
- * @param future output future, must be freed by caller, pass NULL to avoid allocation
  *
  * @return
  */
@@ -291,7 +297,6 @@ cass_session_prepare(CassSession* session,
  *
  * @param session
  * @param statement
- * @param future output future, must be freed by caller, pass NULL to avoid allocation
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -304,8 +309,7 @@ cass_session_exec(CassSession* session,
  * caller.
  *
  * @param session
- * @param statement
- * @param future output future, must be freed by caller, pass NULL to avoid allocation
+ * @param batch
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -397,7 +401,7 @@ cass_future_error_message(CassFuture* future);
 /**
  * Obtain the code from an error structure.
  *
- * @param error
+ * @param future
  *
  * @return error source
  *
@@ -408,7 +412,7 @@ cass_future_error_source(CassFuture* future);
 /**
  * Obtain the source from an error structure.
  *
- * @param error
+ * @param future
  *
  * @return source code
  *
@@ -426,10 +430,8 @@ cass_future_error_code(CassFuture* future);
  * Initialize an ad-hoc query statement
  *
  * @param statement string
- * @param statement_length statement string length
  * @param parameter_count number of bound paramerters
  * @param consistency statement read/write consistency
- * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -518,7 +520,6 @@ cass_statement_bind_bool(CassStatement* statement,
  * @param statement
  * @param index
  * @param value
- * @param length
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -533,7 +534,6 @@ cass_statement_bind_string(CassStatement* statement,
  * @param statement
  * @param index
  * @param value
- * @param length
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -568,8 +568,7 @@ cass_statement_bind_inet(CassStatement* statement,
  * @param statement
  * @param index
  * @param scale
- * @param value
- * @param length
+ * @param varint
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -606,17 +605,15 @@ cass_prepared_free(const CassPrepared* prepared);
  * Initialize a bound statement from a pre-prepared statement
  * parameters
  *
- * @param session
  * @param prepared the previously prepared statement
  * @param parameter_count number of bound paramerters
  * @param consistency statement read/write consistency
- * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
 CASS_EXPORT CassStatement*
 cass_prepared_bind(const CassPrepared* prepared,
-                   cass_size_t paramater_count,
+                   cass_size_t parameter_count,
                    CassConsistency consistency);
 
 /***********************************************************************************
@@ -728,7 +725,6 @@ cass_result_column_count(const CassResult* result);
  *
  * @param result
  * @param index
- * @param coltype output
  *
  * @return
  */
@@ -755,7 +751,7 @@ cass_iterator_from_result(const CassResult* result);
 /**
  * Create new iterator for the specified row.
  *
- * @param result
+ * @param row
  *
  * @return
  */
@@ -765,7 +761,7 @@ cass_iterator_from_row(const CassRow* row);
 /**
  * Create new iterator for the specified collection.
  *
- * @param result
+ * @param value
  *
  * @return
  */
@@ -806,7 +802,6 @@ cass_iterator_get_value(CassIterator *iterator);
  *
  * @param row
  * @param index
- * @param value
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -824,8 +819,8 @@ cass_row_get_column(const CassRow*  row,
  * Decode the specified value. Value may be a column, collection item, map key, or map
  * value.
  *
- * @param source
  * @param value
+ * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -837,8 +832,8 @@ cass_value_get_int32(const CassValue* value,
  * Decode the specified value. Value may be a column, collection item, map key, or map
  * value.
  *
- * @param source
  * @param value
+ * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -850,8 +845,8 @@ cass_value_get_int64(const CassValue* value,
  * Decode the specified value. Value may be a column, collection item, map key, or map
  * value.
  *
- * @param source
  * @param value
+ * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -863,8 +858,8 @@ cass_value_get_float(const CassValue* value,
  * Decode the specified value. Value may be a column, collection item, map key, or map
  * value.
  *
- * @param source
  * @param value
+ * @param output
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -893,8 +888,9 @@ cass_value_get_bytes(const CassValue* value,
  * Decode the specified value. Value may be a column, collection item, map key, or map
  * value.
  *
- * @param source
  * @param value
+ * @param output_scale
+ * @param output_varint
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -907,8 +903,7 @@ cass_value_get_decimal(const CassValue* value,
  * Get the collection sub-type. Works for collections that have a single sub-type
  * (lists and sets).
  *
- * @param collection
- * @param output
+ * @param value
  *
  * @return 0 if successful, otherwise error occured
  */
@@ -921,7 +916,7 @@ cass_value_is_collection(const CassValue* value);
 /**
  * Get the number of items in a collection. Works for all collection types.
  *
- * @param source collection column
+ * @param collection column
  *
  * @return size, 0 if error
  */
@@ -952,6 +947,7 @@ cass_uuid_v1(CassUuid* output);
 /**
  * Generate a new V1 (time) UUID for the specified time
  *
+ * @param time
  * @param output
  */
 CASS_EXPORT void


### PR DESCRIPTION
Builds the Doxygen and stores in docs/html directory.

$ cmake . 
$ make doc

Fixed up all warnings in the Doxygen comments in cassandra.h file.
TBD: 3 typedef structs are showing up in the classes listing.
All of the other global C functions and typedefs are showing up at:
cpp-driver/docs/html/cassandra_8h.html
