### PR TITLE
Fixes cass_batch_free to release ref counted batch

### DIFF
--- a/src/batch_request.cpp
+++ b/src/batch_request.cpp
@@ -24,7 +24,7 @@ CassBatch* cass_batch_new(CassConsistency consistency, CassBatchType type) {
 }
 
 void cass_batch_free(CassBatch* batch) {
-  delete batch->from();
+  batch->release();
 }
 
 CassError cass_batch_add_statement(CassBatch* batch, CassStatement* statement) {


### PR DESCRIPTION
Proposed fix for assertion failures in RefCount::release. cass_batch_free should propably release batch instead of direct delete.

JIRA: CPP-116
