### PR TITLE
Fix assertion failure on connection write error.

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -106,6 +106,9 @@ void Connection::Request::change_state(Connection::Request::State next_state) {
       } else if (next_state == REQUEST_STATE_WRITE_TIMEOUT) {
         connection->timed_out_request_count_++;
         state_ = next_state;
+      } else if (next_state == REQUEST_STATE_DONE) {
+        stop_timer();
+        state_ = next_state;
       } else {
         assert(false && "Invalid request state after writing");
       }


### PR DESCRIPTION
I've been doing some stress tests with my application and ran into this assertion failure occasionally when my one node installation of Cassandra becomes overloaded and starts dropping messages. Narrowed it down to this problem but not sure this is actually the correct fix. Thanks!

Connection::on_write on failure attempts to transition the state from REQUEST_STATE_WRITING to REQUEST_STATE_DONE. This caused Connection::Request::change_state to immediately kill the application with assert(false && "Invalid request state after writing").
