### PR TITLE
CassError is an enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ The driver has been built and tested using Microsoft Visual Studio 2010 and 2013
 
 To obtain dependencies:
 * Download and install CMake for Windows. Make sure to select the option "Add CMake to the system PATH for all users" or "Add CMake to the system PATH for current user".
-* Download and build the latest release of libuv 0.10 from https://github.com/joyent/libuv/releases. 
-  1. Follow the instructions [here](https://github.com/joyent/libuv#windows). 
+* Download and build the latest release of libuv 0.10 from https://github.com/joyent/libuv/releases.
+  1. Follow the instructions [here](https://github.com/joyent/libuv#windows).
   2. Open up the generated Visual Studio solution "uv.sln".
   3. If you want a 64-bit build you will need to create a "x64" solution platform in the "Configuration Manager".
   4. Open "Properties" on the "libuv" project. Set "Multi-threaded DLL (/MD)" for the "Configuration Properties -> C/C++ -> Code Generation -> Runtime Library" option.
@@ -123,7 +123,7 @@ There are several examples provided here: [examples](https://github.com/datastax
 #include <cassandra.h>
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = cass_cluster_new();
   CassFuture* session_future = NULL;
   CassString contact_points = cass_string_init("127.0.0.1,127.0.0.2,127.0.0.3");

--- a/examples/async/async.c
+++ b/examples/async/async.c
@@ -37,7 +37,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -55,7 +55,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -74,7 +74,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 void insert_into_async(CassSession* session, const char* key) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassString query = cass_string_init("INSERT INTO async (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);");
 
@@ -113,7 +113,7 @@ void insert_into_async(CassSession* session, const char* key) {
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -45,7 +45,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -63,7 +63,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -82,7 +82,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 CassError insert_into_basic(CassSession* session, const char* key, const Basic* basic) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);");
@@ -111,7 +111,7 @@ CassError insert_into_basic(CassSession* session, const char* key, const Basic* 
 }
 
 CassError select_from_basic(CassSession* session, const char* key, Basic* basic) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("SELECT * FROM examples.basic WHERE key = ?");
@@ -150,7 +150,7 @@ CassError select_from_basic(CassSession* session, const char* key, Basic* basic)
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/batch/batch.c
+++ b/examples/batch/batch.c
@@ -41,7 +41,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -59,7 +59,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -78,7 +78,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 CassError prepare_insert_into_batch(CassSession* session, const CassPrepared** prepared) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassString query = cass_string_init("INSERT INTO examples.pairs (key, value) VALUES (?, ?)");
 
@@ -98,7 +98,7 @@ CassError prepare_insert_into_batch(CassSession* session, const CassPrepared** p
 }
 
 CassError insert_into_batch_with_prepared(CassSession* session, const CassPrepared* prepared, const Pair* pairs) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassBatch* batch = cass_batch_new(CASS_BATCH_TYPE_LOGGED);
 
@@ -138,7 +138,7 @@ CassError insert_into_batch_with_prepared(CassSession* session, const CassPrepar
 
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/collections/collections.c
+++ b/examples/collections/collections.c
@@ -34,7 +34,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -52,7 +52,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -71,7 +71,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 CassError insert_into_collections(CassSession* session, const char* key, const char* items[]) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassCollection* collection = NULL;
@@ -104,7 +104,7 @@ CassError insert_into_collections(CassSession* session, const char* key, const c
 }
 
 CassError select_from_collections(CassSession* session, const char* key) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("SELECT items FROM examples.collections WHERE key = ?");
@@ -149,7 +149,7 @@ CassError select_from_collections(CassSession* session, const char* key) {
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/paging/paging.c
+++ b/examples/paging/paging.c
@@ -37,7 +37,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -55,7 +55,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -74,7 +74,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 void insert_into_paging(CassSession* session, const char* key) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassString query = cass_string_init("INSERT INTO paging (key, value) VALUES (?, ?);");
 
   CassFuture* futures[NUM_CONCURRENT_REQUESTS];
@@ -158,7 +158,7 @@ void select_from_paging(CassSession* session) {
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/perf/perf.c
+++ b/examples/perf/perf.c
@@ -43,7 +43,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect_keyspace(cluster, "examples");
 
   *output = NULL;
@@ -61,7 +61,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -143,7 +143,7 @@ void select_from_perf(CassSession* session) {
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/prepared/prepared.c
+++ b/examples/prepared/prepared.c
@@ -44,7 +44,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -62,7 +62,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
   CassFuture* future = cass_session_execute(session, statement);
 
@@ -80,7 +80,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 CassError insert_into_basic(CassSession* session, const char* key, const Basic* basic) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);");
@@ -110,7 +110,7 @@ CassError insert_into_basic(CassSession* session, const char* key, const Basic* 
 }
 
 CassError prepare_select_from_basic(CassSession* session, const CassPrepared** prepared) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassString query = cass_string_init("SELECT * FROM examples.basic WHERE key = ?");
 
@@ -130,7 +130,7 @@ CassError prepare_select_from_basic(CassSession* session, const CassPrepared** p
 }
 
 CassError select_from_basic(CassSession* session, const CassPrepared * prepared, const char* key, Basic* basic) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
 
@@ -169,7 +169,7 @@ CassError select_from_basic(CassSession* session, const CassPrepared * prepared,
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -20,7 +20,7 @@
 #include <cassandra.h>
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = cass_cluster_new();
   CassFuture* session_future = NULL;
   CassString contact_points = cass_string_init("127.0.0.1,127.0.0.2,127.0.0.3");

--- a/examples/uuids/uuids.c
+++ b/examples/uuids/uuids.c
@@ -44,7 +44,7 @@ CassCluster* create_cluster() {
 }
 
 CassError connect_session(CassCluster* cluster, CassSession** output) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = cass_cluster_connect(cluster);
 
   *output = NULL;
@@ -62,7 +62,7 @@ CassError connect_session(CassCluster* cluster, CassSession** output) {
 }
 
 CassError execute_query(CassSession* session, const char* query) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassFuture* future = NULL;
   CassStatement* statement = cass_statement_new(cass_string_init(query), 0);
 
@@ -81,7 +81,7 @@ CassError execute_query(CassSession* session, const char* query) {
 }
 
 CassError insert_into_log(CassSession* session, const char* key, CassUuid time, const char* entry) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("INSERT INTO examples.log (key, time, entry) VALUES (?, ?, ?);");
@@ -108,7 +108,7 @@ CassError insert_into_log(CassSession* session, const char* key, CassUuid time, 
 }
 
 CassError select_from_log(CassSession* session, const char* key) {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
   CassString query = cass_string_init("SELECT * FROM examples.log WHERE key = ?");
@@ -156,7 +156,7 @@ CassError select_from_log(CassSession* session, const char* key) {
 }
 
 int main() {
-  CassError rc = 0;
+  CassError rc = CASS_OK;
   CassCluster* cluster = create_cluster();
   CassSession* session = NULL;
   CassFuture* close_future = NULL;


### PR DESCRIPTION
I copied the example from the README into a file example.cpp and tried to compile it.  I got this error:

```
example.cpp: In function ‘int main()’:
example.cpp:6: error: invalid conversion from ‘int’ to ‘CassError’
```

It's only in C++ that it's an error to initialize as `CassError rc = 0;`, so I guess that the example was intended to be plain C.  

Cleanest, though, seems to be to write code that's valid in both languages, so I've changed all examples to go `CassError rc = CASS_OK;`.
