### PR TITLE
Short-circuit control startup on auth errors

### DIFF
--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -83,6 +83,8 @@ public:
 
   const std::string& address_string() { return addr_string_; }
 
+  const std::string& auth_error() { return auth_error_; }
+
   const std::string& keyspace() { return keyspace_; }
 
   void close();
@@ -153,6 +155,7 @@ private:
   ConnectionState state_;
   bool is_defunct_;
   bool is_invalid_protocol_;
+  std::string auth_error_;
 
   List<Handler> pending_requests_;
 

--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -220,6 +220,15 @@ void ControlConnection::on_connection_closed(Connection* connection) {
   // closed
   connection_ = NULL;
 
+  if (state_ == CONTROL_STATE_NEW) {
+    if (!connection->auth_error().empty()) {
+      if (error_callback_) {
+        error_callback_(CASS_ERROR_SERVER_BAD_CREDENTIALS, connection->auth_error());
+        return;
+      }
+    }
+  }
+
   reconnect();
 }
 


### PR DESCRIPTION
Auth errors are special-cased to avoid retrying on all contact points.
