### PR TITLE
previous code was exercising some changes on the uuid boost::mt19937_64 ...

### DIFF
--- a/src/uuids.cpp
+++ b/src/uuids.cpp
@@ -20,6 +20,7 @@
 #include "scoped_mutex.hpp"
 #include "get_time.hpp"
 
+#include "third_party/boost/boost/random/mersenne_twister.hpp"
 #include "third_party/boost/boost/random/random_device.hpp"
 
 extern "C" {
@@ -60,6 +61,9 @@ void cass_uuid_string(CassUuid uuid, char* output) {
 
 namespace {
 
+  boost::random_device rd;
+  boost::mt19937_64 ng_(rd());
+
 class UuidsInitializer {
 public:
   UuidsInitializer() { cass::Uuids::initialize_(); }
@@ -71,15 +75,11 @@ UuidsInitializer uuids_intitalizer_;
 
 namespace cass {
 
-boost::mt19937_64 Uuids::ng_;
 uv_mutex_t Uuids::mutex_;
 boost::atomic<uint64_t> Uuids::last_timestamp_;
 uint64_t Uuids::CLOCK_SEQ_AND_NODE;
 
 void Uuids::initialize_() {
-  boost::random_device rd;
-  ng_.seed(rd());
-
   uv_mutex_init(&mutex_);
   last_timestamp_ = 0L;
   CLOCK_SEQ_AND_NODE = make_clock_seq_and_node();

--- a/src/uuids.hpp
+++ b/src/uuids.hpp
@@ -18,7 +18,6 @@
 #define __CASS_UUIDS_HPP_INCLUDED__
 
 #include "third_party/boost/boost/atomic.hpp"
-#include "third_party/boost/boost/random/mersenne_twister.hpp"
 #include "third_party/boost/boost/cstdint.hpp"
 
 #include <uv.h>
@@ -76,7 +75,6 @@ private:
 private:
   static uv_mutex_t mutex_;
   static boost::atomic<uint64_t> last_timestamp_;
-  static boost::mt19937_64 ng_;
 };
 
 } // namespace cass


### PR DESCRIPTION
...Uuids::ng_

object through the UuidsInitializer.
At issue was that the constructor of the Uuids::ng_ object was not called at the time
the seed was being set in Uuids::initialize_(). This surfaced in ng_ always having
its default initilization and always generating the same sequence of uuids through
the cass_uuid_generate_random call.

This fix will make sure the seed from the random_device is not overwritten
