### PR TITLE
Add __attribute(format) to remove clang warnings/errors

### DIFF
--- a/src/error_response.cpp
+++ b/src/error_response.cpp
@@ -52,11 +52,11 @@ bool check_error_or_invalid_response(const std::string& prefix, uint8_t expected
   if (response->opcode() == CQL_OPCODE_ERROR) {
     std::ostringstream ss;
     ss << prefix << ": Error response";
-    logger->error(error_response_message(ss.str(), static_cast<ErrorResponse*>(response)).c_str());
+    logger->error("%s",error_response_message(ss.str(), static_cast<ErrorResponse*>(response)).c_str());
   } else {
     std::ostringstream ss;
     ss << prefix << ": Unexpected opcode " << opcode_to_string(response->opcode());
-    logger->error(ss.str().c_str());
+    logger->error("%s",ss.str().c_str());
   }
 
   return true;

--- a/src/logger.hpp
+++ b/src/logger.hpp
@@ -53,15 +53,15 @@ public:
     va_end(args);                \
   }
 
-  void critical(const char* format, ...) { LOG_MESSAGE(CASS_LOG_CRITICAL); }
+  void critical(const char* format, ...) __attribute__((format(printf,2,3))) { LOG_MESSAGE(CASS_LOG_CRITICAL); }
 
-  void error(const char* format, ...) { LOG_MESSAGE(CASS_LOG_ERROR); }
+  void error(const char* format, ...) __attribute__((format(printf,2,3))) { LOG_MESSAGE(CASS_LOG_ERROR); }
 
-  void warn(const char* format, ...) { LOG_MESSAGE(CASS_LOG_WARN); }
+  void warn(const char* format, ...) __attribute__((format(printf,2,3))) { LOG_MESSAGE(CASS_LOG_WARN); }
 
-  void info(const char* format, ...) { LOG_MESSAGE(CASS_LOG_INFO); }
+  void info(const char* format, ...) __attribute__((format(printf,2,3))) { LOG_MESSAGE(CASS_LOG_INFO); }
 
-  void debug(const char* format, ...) { LOG_MESSAGE(CASS_LOG_DEBUG); }
+  void debug(const char* format, ...) __attribute__((format(printf,2,3))) { LOG_MESSAGE(CASS_LOG_DEBUG); }
 
 #undef LOG_MESSAGE
 
@@ -74,13 +74,13 @@ private:
 
   void close() { log_queue_.close_handles(); }
 
-  std::string format_message(const char* format, va_list args) {
+  std::string format_message(const char* format, va_list args) __attribute__((format(printf,2,0))) {
     char buffer[1024];
     int n = vsnprintf(buffer, sizeof(buffer), format, args);
     return std::string(buffer, n);
   }
 
-  void log(CassLogLevel severity, const char* format, va_list args) {
+  void log(CassLogLevel severity, const char* format, va_list args) __attribute__((format(printf,3,0))) {
     LogMessage* log_message = new LogMessage;
     log_message->severity = severity;
     log_message->message = format_message(format, args);

--- a/src/schema_change_handler.cpp
+++ b/src/schema_change_handler.cpp
@@ -115,13 +115,13 @@ void SchemaChangeHandler::on_set(const ResponseVec& responses) {
   if (has_error) return;
 
   if (has_schema_agreement(responses)) {
-    logger_->debug("SchemaChangeHandler: Found schema agreement in %llu ms", elaspsed_);
+    logger_->debug("SchemaChangeHandler: Found schema agreement in %llu ms", (unsigned long long)elaspsed_);
     request_handler_->set_response(request_response_);
     return;
   } else if (elaspsed_ >= MAX_SCHEMA_AGREEMENT_WAIT_MS) {
-    logger_->warn("SchemaChangeHandler: No schema aggreement on live nodes after %llu ms. "
+    logger_->warn("SchemaChangeHandler: No schema agreement on live nodes after %llu ms. "
                   "Schema may not be up-to-date on some nodes.",
-                  elaspsed_);
+                  (unsigned long long)elaspsed_);
     request_handler_->set_response(request_response_);
     return;
   }
@@ -140,15 +140,13 @@ void SchemaChangeHandler::on_set(const ResponseVec& responses) {
 }
 
 void SchemaChangeHandler::on_error(CassError code, const std::string& message) {
-  std::ostringstream ss;
-  ss << "SchemaChangeHandler: An error occured waiting for schema agreement: '" << message
-     << "' (0x" << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << code << ")";
-  logger_->error(ss.str().c_str());
+  logger_->error("SchemaChangeHandler: An error occurred waiting for schema agreement: '%s' "
+                 "(0x%08x)", message.c_str(), (unsigned)code);
   request_handler_->set_response(request_response_);
 }
 
 void SchemaChangeHandler::on_timeout() {
-  logger_->error("SchemaChangeHandler: A timeout occured waiting for schema agreement");
+  logger_->error("SchemaChangeHandler: A timeout occurred waiting for schema agreement");
   request_handler_->set_response(request_response_);
 }
 


### PR DESCRIPTION
Also fix a couple of spelling mistakes.

Signed-off-by: Gavin Halliday gavin.halliday@lexisnexis.com
