### PR TITLE
Schema metadata isolation

### DIFF
--- a/src/cluster_metadata.hpp
+++ b/src/cluster_metadata.hpp
@@ -24,9 +24,11 @@ namespace cass {
 
 class ClusterMetadata {
 public:
+  ~ClusterMetadata();
+  int init();
   void clear();
   void update_keyspaces(ResultResponse* result);
-  void update_tables(ResultResponse* table_result, ResultResponse* col_result) { schema_.update_tables(table_result, col_result); }
+  void update_tables(ResultResponse* table_result, ResultResponse* col_result);
   void set_partitioner(const std::string& partitioner_class) { token_map_.set_partitioner(partitioner_class); }
   void update_host(SharedRefPtr<Host>& host, const TokenStringList& tokens) { token_map_.update_host(host, tokens); }
   void build() { token_map_.build(); }
@@ -35,6 +37,7 @@ public:
   void remove_host(SharedRefPtr<Host>& host) { token_map_.remove_host(host); }
 
   const Schema& schema() const { return schema_; }
+  Schema* copy_schema() const;// synchronized copy for API
 
   void set_protocol_version(int version) { schema_.set_protocol_version(version); }
 
@@ -43,6 +46,9 @@ public:
 private:
   Schema schema_;
   TokenMap token_map_;
+
+  // used to synch schema updates and copies
+  mutable uv_mutex_t mutex_;
 };
 
 } // namespace cass

--- a/src/request_handler.hpp
+++ b/src/request_handler.hpp
@@ -44,7 +44,7 @@ public:
       , schema(schema) {}
 
   std::string statement;
-  const Schema& schema;
+  Schema schema;
 };
 
 class RequestHandler : public Handler {

--- a/src/schema_metadata.cpp
+++ b/src/schema_metadata.cpp
@@ -109,7 +109,6 @@ const SchemaMetadata* Schema::get(const std::string& name) const {
 }
 
 Schema::KeyspacePointerMap Schema::update_keyspaces(ResultResponse* result) {
-  ScopedMutex l(&mutex_);
   KeyspacePointerMap updates;
 
   SharedRefPtr<RefBuffer> buffer = result->buffer();
@@ -133,7 +132,6 @@ Schema::KeyspacePointerMap Schema::update_keyspaces(ResultResponse* result) {
 }
 
 void Schema::update_tables(ResultResponse* table_result, ResultResponse* col_result) {
-  ScopedMutex l(&mutex_);
   SharedRefPtr<RefBuffer> buffer = table_result->buffer();
 
   table_result->decode_first_row();

--- a/src/schema_metadata.hpp
+++ b/src/schema_metadata.hpp
@@ -219,20 +219,7 @@ public:
 
   Schema()
     : keyspaces_(new KeyspaceMetadata::Map)
-    , protocol_version_(0) {
-    uv_mutex_init(&mutex_);
-  }
-
-  ~Schema() {
-    uv_mutex_destroy(&mutex_);
-  }
-
-  Schema* clone() const {
-    ScopedMutex l(&mutex_);
-    Schema* out = new Schema();
-    out->keyspaces_ = keyspaces_;
-    return out;
-  }
+    , protocol_version_(0) {}
 
   void set_protocol_version(int version) {
     protocol_version_ = version;
@@ -259,15 +246,9 @@ private:
   // more fine grain, but it might not be worth the work.
   CopyOnWritePtr<KeyspaceMetadata::Map> keyspaces_;
 
-  // synchronize updates and copies
-  mutable uv_mutex_t mutex_;
-
   // Only used internally on a single thread, there's
   // no need for copy-on-write.
   int protocol_version_;
-
-private:
-  DISALLOW_COPY_AND_ASSIGN(Schema);
 };
 
 } // namespace cass

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -71,6 +71,8 @@ Session::Session(const Config& config)
 int Session::init() {
   int rc = logger_->init();
   if (rc != 0) return rc;
+  rc = cluster_meta_.init();
+  if (rc != 0) return rc;
   rc = EventThread<SessionEvent>::init(config_.queue_size_event());
   if (rc != 0) return rc;
   request_queue_.reset(

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -103,7 +103,7 @@ public:
   Future* prepare(const char* statement, size_t length);
   Future* execute(const RoutableRequest* statement);
 
-  const Schema* copy_schema() const { return cluster_meta_.schema().clone(); }
+  const Schema* copy_schema() const { return cluster_meta_.copy_schema(); }
 
 private:
   void close_handles();


### PR DESCRIPTION
Changing ResponseFuture.schema to reference broke copy-on-write semantics for prepare statements. This change reverts that, and moves schema meta synchronization up to ClusterMetadata:

Restore copy-on-write semantics for schema carried with prepare request.
Avoid mutex init/destroy for each prepare.
