### PR TITLE
Adding a NULL check to column count

### DIFF
--- a/src/result_response.hpp
+++ b/src/result_response.hpp
@@ -58,7 +58,7 @@ public:
 
   bool has_more_pages() const { return has_more_pages_; }
 
-  int32_t column_count() const { return metadata_->column_count(); }
+  int32_t column_count() const { return (metadata_ ? metadata_->column_count() : 0); }
 
   bool no_metadata() const { return !metadata_; }
 


### PR DESCRIPTION
The metadata_ has the potential for being NULL; this will correct a potential segfault when iterating over a result (e.g. DELETE statement).
