### PR TITLE
Clean-compile on 32-bit architectures

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -296,9 +296,9 @@ void Connection::consume(char* input, size_t size) {
       ScopedPtr<ResponseMessage> response(response_.release());
       response_.reset(new ResponseMessage());
 
-      LOG_TRACE("Consumed message type %s with stream %d, input %lu, remaining %d on host %s",
+      LOG_TRACE("Consumed message type %s with stream %d, input %d, remaining %d on host %s",
                 opcode_to_string(response->opcode()).c_str(), static_cast<int>(response->stream()),
-                size, remaining, addr_string_.c_str());
+                (int)size, remaining, addr_string_.c_str());
 
       if (response->stream() < 0) {
         if (response->opcode() == CQL_OPCODE_EVENT) {
@@ -772,7 +772,7 @@ void Connection::PendingWriteSsl::encrypt() {
   BufferVec::const_iterator it = buffers_.begin(),
       end = buffers_.end();
 
-  LOG_TRACE("Copying %lu bufs", buffers_.size());
+  LOG_TRACE("Copying %d bufs", (int)buffers_.size());
 
   bool is_done = (it == end);
 
@@ -809,7 +809,7 @@ void Connection::PendingWriteSsl::encrypt() {
     }
   }
 
-  LOG_TRACE("Copied %lu bytes for encryption", total);
+  LOG_TRACE("Copied %d bytes for encryption", (int)total);
 }
 
 void Connection::PendingWriteSsl::flush() {
@@ -830,7 +830,7 @@ void Connection::PendingWriteSsl::flush() {
     FixedVector<uv_buf_t, SSL_ENCRYPTED_BUFS_COUNT> bufs;
     encrypted_size_ = ssl_session->outgoing().peek_multiple(prev_pos, &bufs);
 
-    LOG_TRACE("Sending %lu encrypted bytes", encrypted_size_);
+    LOG_TRACE("Sending %d encrypted bytes", (int)encrypted_size_);
 
     uv_stream_t* sock_stream = copy_cast<uv_tcp_t*, uv_stream_t*>(&connection_->socket_);
     uv_write(&req_, sock_stream, bufs.data(), bufs.size(), PendingWriteSsl::on_write);

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -51,8 +51,8 @@ Pool::Pool(IOWorker* io_worker,
     , is_pending_flush_(false) {}
 
 Pool::~Pool() {
-  LOG_DEBUG("Pool dtor with %lu pending requests pool(%p)",
-            pending_requests_.size(), static_cast<void*>(this));
+  LOG_DEBUG("Pool dtor with %d pending requests pool(%p)",
+            (int)pending_requests_.size(), static_cast<void*>(this));
   while (!pending_requests_.is_empty()) {
     RequestHandler* request_handler
         = static_cast<RequestHandler*>(pending_requests_.front());
@@ -136,8 +136,8 @@ void Pool::add_pending_request(RequestHandler* request_handler) {
   pending_requests_.add_to_back(request_handler);
 
   if (pending_requests_.size() % 10 == 0) {
-    LOG_DEBUG("%lu request%s pending on %s pool(%p)",
-              pending_requests_.size() + 1,
+    LOG_DEBUG("%d request%s pending on %s pool(%p)",
+              (int)pending_requests_.size() + 1,
               pending_requests_.size() > 0 ? "s":"",
               address_.to_string().c_str(),
               static_cast<void*>(this));


### PR DESCRIPTION
32-bit build errors like this:

    cpp-driver/src/connection.cpp: In member function ‘void cass::Connection::consume(char*, size_t)’:
    cpp-driver/src/connection.cpp:301: error: format ‘%lu’ expects type ‘long unsigned int’, but argument 7 has type ‘size_t’

I've fixed by casting to int, failing to find a more portable solution.