### PR TITLE
Test correct flag for using external boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ else()
     ${PROJECT_SOURCE_DIR}/src/ssl/ssl_no_impl.cpp)
 endif()
 
-if(Boost_FOUND)
+if(CASS_USE_EXTERNAL_BOOST)
   message(WARNING "Using the external version of Boost")
 
   if(NOT (Boost_ATOMIC_FOUND AND Boost_RANDOM_FOUND AND Boost_SYSTEM_FOUND))


### PR DESCRIPTION
When including the cmake file from a parent cmake project, Boost_FOUND may
be set even though we don't want to use an external boost (for example,
because the version of boost is not new enough to support the test code)

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>