### PR TITLE
Use memcpy to avoid strict aliasing warnings with gcc 4.4

### DIFF
--- a/src/serialization.hpp
+++ b/src/serialization.hpp
@@ -116,22 +116,32 @@ inline char* decode_int64(char* input, cass_int64_t& output) {
 
 inline void encode_float(char* output, float value) {
   BOOST_STATIC_ASSERT(std::numeric_limits<float>::is_iec559);
-  encode_int32(output, *copy_cast<float*, int32_t*>(&value));
+  int32_t int_value;
+  memcpy(&int_value, &value, sizeof(int_value));
+  encode_int32(output, int_value);
 }
 
 inline char* decode_float(char* input, float& output) {
   BOOST_STATIC_ASSERT(std::numeric_limits<float>::is_iec559);
-  return decode_int32(input, *copy_cast<float*, int32_t*>(&output));
+  int32_t int_value;
+  char* pos = decode_int32(input, int_value);
+  memcpy(&output, &int_value, sizeof(int_value));
+  return pos;
 }
 
 inline void encode_double(char* output, double value) {
   BOOST_STATIC_ASSERT(std::numeric_limits<double>::is_iec559);
-  encode_int64(output, *copy_cast<double*, cass_int64_t*>(&value));
+  cass_int64_t int_value;
+  memcpy(&int_value, &value, sizeof(int_value));
+  encode_int64(output, int_value);
 }
 
 inline char* decode_double(char* input, double& output) {
   BOOST_STATIC_ASSERT(std::numeric_limits<double>::is_iec559);
-  return decode_int64(input, *copy_cast<double*, cass_int64_t*>(&output));
+  cass_int64_t int_value;
+  char* pos = decode_int64(input, int_value);
+  memcpy(&output, &int_value, sizeof(int_value));
+  return pos;
 }
 
 inline char* decode_string(char* input, char** output, size_t& size) {


### PR DESCRIPTION
We hit this problem compiling on Ubuntu 10.04 with g++ 4.4.

This is a better solution to avoid the strict aliasing warnings when casting
a float/double to an integer.  Strangely, older versions of gcc are better at
reporting a warning in this situation than more recent versions.

The previous copy_cast solution to the alias problem doesn't really solve the problem.  The
code is still accessing a float variable through an integer pointer.  The memcpy of the pointer
inside the copy_cast is enough to stop the compiler tracking that it is an alias, but interestingly
on 4.4 the compiler does track it - hence the warning.

This change uses memcpy() to copy the value, so the same memory location is never aliased.

I compiled the code and as far as I could see from the assembler output the generated code was the same (g++ 4.8.2) before after after the patch.

Signed-off-by: Gavin Halliday <gavin.halliday@lexisnexis.com>