### PR TITLE
join() call is not happening in release builds

### DIFF
--- a/src/loop_thread.hpp
+++ b/src/loop_thread.hpp
@@ -59,7 +59,9 @@ public:
   void join() {
     if (is_joinable_) {
       is_joinable_ = false;
-      assert(uv_thread_join(&thread_) == 0);
+      int rc = uv_thread_join(&thread_);
+      (void) rc;
+      assert(rc == 0);
     }
   }
 


### PR DESCRIPTION
The assert() macro expands to do nothing in a release build, so any side
effects of the expression being asserted do not occur.

This was causing random crashes and memory corruptions in a release-mode build
of the driver.

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>