### PR TITLE
Fix compile error on Clang 6.0

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -82,7 +82,10 @@ void Logger::LogThread::log(CassLogLevel severity,
     ""
   };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
   vsnprintf(message.message, sizeof(message.message), format, args);
+#pragma GCC diagnostic pop
 
   if (!log_queue_.enqueue(message)) {
     if (has_been_warned_) {


### PR DESCRIPTION
Fix build failure compiling on OSX (clang reports version Apple LLVM
version 6.0 (clang-600.0.56))

Signed-off-by: Richard Chapman <rchapman@hpccsystems.com>