### PR TITLE
Pick the right STRERROR_R macro for FreeBSD

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -61,7 +61,7 @@ namespace cass {
 
 #define STRERROR_BUFSIZE_ 256
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(FreeBSD)
 #define STRERROR_R_(errno, buf, bufsize) (strerror_r(errno, buf, bufsize), buf)
 #else
 #define STRERROR_R_(errno, buf, bufsize) strerror_r(errno, buf, bufsize)


### PR DESCRIPTION
FreeBSD needs the same STRERROR_R that OS X does.