### PR TITLE
Update homebrew formula to use version 2.0

### DIFF
--- a/packaging/homebrew/cassandra-cpp-driver.rb
+++ b/packaging/homebrew/cassandra-cpp-driver.rb
@@ -3,7 +3,7 @@ require "formula"
 class CassandraCppDriver < Formula
   homepage "http://datastax.github.io/cpp-driver/"
   url "https://github.com/datastax/cpp-driver/archive/2.0.0.tar.gz"
-  sha1 "7bb41ba0caf5a8211bc2ed9dc8c99563e4fd047e"
+  sha1 "f00de7ce2c6cc702426d443639d7bf9855fbe8a3"
   version "2.0.0"
 
   head "git://github.com:datastax/cpp-driver.git", :branch => "2.0"

--- a/packaging/homebrew/cassandra-cpp-driver.rb
+++ b/packaging/homebrew/cassandra-cpp-driver.rb
@@ -3,8 +3,8 @@ require "formula"
 class CassandraCppDriver < Formula
   homepage "http://datastax.github.io/cpp-driver/"
   url "https://github.com/datastax/cpp-driver/archive/2.0.1.tar.gz"
-  sha1 "f00de7ce2c6cc702426d443639d7bf9855fbe8a3"
-  version "2.0.0"
+  sha1 "67a5b4e52ec421407c34ba7df109faeeaf4ef6dd"
+  version "2.0.1"
 
   head "git://github.com:datastax/cpp-driver.git", :branch => "2.0"
 

--- a/packaging/homebrew/cassandra-cpp-driver.rb
+++ b/packaging/homebrew/cassandra-cpp-driver.rb
@@ -2,11 +2,11 @@ require "formula"
 
 class CassandraCppDriver < Formula
   homepage "http://datastax.github.io/cpp-driver/"
-  url "https://github.com/datastax/cpp-driver/archive/1.0.0.tar.gz"
-  sha1 "087aa2cf00e3c6f0eb75bb0471b78d255ea94562"
-  version "1.0.0"
+  url "https://github.com/datastax/cpp-driver/archive/2.0.0.tar.gz"
+  sha1 "7bb41ba0caf5a8211bc2ed9dc8c99563e4fd047e"
+  version "2.0.0"
 
-  head "git://github.com:datastax/cpp-driver.git", :branch => "1.0"
+  head "git://github.com:datastax/cpp-driver.git", :branch => "2.0"
 
   depends_on "cmake" => :build
   depends_on "libuv"

--- a/packaging/homebrew/cassandra-cpp-driver.rb
+++ b/packaging/homebrew/cassandra-cpp-driver.rb
@@ -2,7 +2,7 @@ require "formula"
 
 class CassandraCppDriver < Formula
   homepage "http://datastax.github.io/cpp-driver/"
-  url "https://github.com/datastax/cpp-driver/archive/2.0.0.tar.gz"
+  url "https://github.com/datastax/cpp-driver/archive/2.0.1.tar.gz"
   sha1 "f00de7ce2c6cc702426d443639d7bf9855fbe8a3"
   version "2.0.0"
 


### PR DESCRIPTION
Just a quick update to the homebrew formula to reflect the new driver version. I tested it here:

brew install https://raw.githubusercontent.com/pmcfadin/cpp-driver/master/packaging/homebrew/cassandra-cpp-driver.rb

Works great. 