### PR TITLE
Support building with Clang 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,6 +421,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # Clang/Intel specific compiler options
   # I disabled long-long warning because boost generates about 50 such warnings
   set(WARNING_COMPILER_FLAGS "-Wall -pedantic -Wextra -Wno-long-long -Wno-unused-parameter -Wno-variadic-macros -Wno-zero-length-array")
+  if(${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER "3.6")
+      set(WARNING_COMPILER_FLAGS "${WARNING_COMPILER_FLAGS} -Wno-unused-local-typedef ")
+  endif()
 
   # OpenSSL is deprecated on later versions of Mac OS X. The long-term solution
   # is to provide a CommonCryto implementation.


### PR DESCRIPTION
Clang 3.6 warns about unused local typedefs and causes a compilation error to occur because of -Wall.
See build log at
http://beefy4.nyi.freebsd.org/data/head-amd64-default/p390348_s284712/logs/cassandra-cpp-driver-2.0.1.log