### PR TITLE
Add timestamp conversion in cass_uuid_min/max_from_time() function to…

### DIFF
--- a/src/uuids.cpp
+++ b/src/uuids.cpp
@@ -70,12 +70,12 @@ void cass_uuid_gen_from_time(CassUuidGen* uuid_gen, cass_uint64_t timestamp, Cas
 }
 
 void cass_uuid_min_from_time(cass_uint64_t timestamp, CassUuid* output) {
-  output->time_and_version = set_version(timestamp, 1);
+  output->time_and_version = set_version(from_unix_timestamp(timestamp), 1);
   output->clock_seq_and_node = MIN_CLOCK_SEQ_AND_NODE;
 }
 
 void cass_uuid_max_from_time(cass_uint64_t timestamp, CassUuid* output) {
-  output->time_and_version = set_version(timestamp, 1);
+  output->time_and_version = set_version(from_unix_timestamp(timestamp), 1);
   output->clock_seq_and_node = MAX_CLOCK_SEQ_AND_NODE;
 }
 


### PR DESCRIPTION
… be consistent with cass_uuid_gen_from_time() function. CPP-283.
In current code cass_uuid_min/max_from_time() do not convert timestamp to internal format which is inconsistent with the behavior of cass_uuid_gen_from_time() that uses from_unix_timestamp(() function for conversion. This commit adds same conversion to cass_uuid_min/max_from_time()  functions.