### PR TITLE
docs: remove cass_string_init from all code samples

### DIFF
--- a/topics/README.md
+++ b/topics/README.md
@@ -80,7 +80,7 @@ CassStatement* statement
   = cass_statement_new("INSERT INTO example (key, value) VALUES (?, ?)", 2);
 
 /* Bind the values using the indices of the bind variables */
-cass_statement_bind_string(statement, 0, cass_string_init("abc"));
+cass_statement_bind_string(statement, 0, "abc");
 cass_statement_bind_int32(statement, 1, 123);
 
 CassFuture* query_future = cass_session_execute(session, statement);

--- a/topics/basics/batches/README.md
+++ b/topics/basics/batches/README.md
@@ -16,21 +16,21 @@ CassBatch* batch = cass_batch_new(CASS_BATCH_TYPE_LOGGED);
  
 {
   CassStatement* statement
-    = cass_statement_new(cass_string_init("INSERT INTO example1(key, value) VALUES ('a', '1')"), 0);
+    = cass_statement_new("INSERT INTO example1(key, value) VALUES ('a', '1')", 0);
   cass_batch_add_statement(batch, statement);
   cass_statement_free(statement);
 }
  
 {
   CassStatement* statement
-    = cass_statement_new(cass_string_init("UPDATE example2 set value = '2' WHERE key = 'b'"), 0);
+    = cass_statement_new("UPDATE example2 set value = '2' WHERE key = 'b'", 0);
   cass_batch_add_statement(batch, statement);
   cass_statement_free(statement);
 }
  
 {
   CassStatement* statement
-    = cass_statement_new(cass_string_init("DELETE FROM example3 WHERE key = 'c'"), 0);
+    = cass_statement_new("DELETE FROM example3 WHERE key = 'c'", 0);
   cass_batch_add_statement(batch, statement);
   cass_statement_free(statement);
 }

--- a/topics/basics/binding_parameters/README.md
+++ b/topics/basics/binding_parameters/README.md
@@ -6,7 +6,7 @@ The ‘?’ marker is used to denote the bind variables in a query string. This 
 /* Create a statement with a single parameter */
 CassStatement* statement = cass_statement_new("SELECT * FROM table1 WHERE column1 = ?", 1);
 
-cass_statement_bind_string(statement, 0, cass_string_init("abc"));
+cass_statement_bind_string(statement, 0, "abc");
 
 /* Execute statement */
 
@@ -22,7 +22,7 @@ Variables can only be bound by name for prepared statements. This limitation exi
 CassStatement* statement = cass_prepared_bind(prepared);
 
 /* The parameter can now be bound by name */
-cass_statement_bind_string_by_name(statement, "column1", cass_string_init("abc"));
+cass_statement_bind_string_by_name(statement, "column1", "abc");
 
 /* Execute statement */
 
@@ -38,7 +38,7 @@ The data of values bound to a statement are copied into the statement. That mean
 CassStatement* statement
   = cass_statement_new("INSERT INTO table1 (column1, column2) VALUES (?, ?)", 2);
 
-cass_statement_bind_string(statement, 0, cass_string_init("abc"));
+cass_statement_bind_string(statement, 0, "abc");
 
 cass_byte_t* bytes;
 cass_statement_bind_custom(statement, 1, 8 * 1024 * 1024, &bytes);
@@ -60,9 +60,9 @@ CassStatement* statement = cass_statement_new(query, 1);
 
 CassCollection* list = cass_collection_new(CASS_COLLECTION_TYPE_LIST, 3);
 
-cass_collection_append_string(list, cass_string_init("123"));
-cass_collection_append_string(list, cass_string_init("456"));
-cass_collection_append_string(list, cass_string_init("789"));
+cass_collection_append_string(list, "123");
+cass_collection_append_string(list, "456");
+cass_collection_append_string(list, "789");
 
 cass_statement_bind_collection(statement, 0, list);
 
@@ -78,11 +78,11 @@ CassStatement* statement = cass_statement_new(query, 1);
 CassCollection* map = cass_collection_new(CASS_COLLECTION_TYPE_MAP, 2);
 
 /* map["abc"] = 123 */
-cass_collection_append_string(map, cass_string_init("abc"));
+cass_collection_append_string(map, "abc");
 cass_collection_append_int32(map, 123);
 
 /* map["def"] = 456 */
-cass_collection_append_string(map, cass_string_init("def"));
+cass_collection_append_string(map, "def");
 cass_collection_append_int32(map, 456);
 
 cass_statement_bind_collection(statement, 0, map);

--- a/topics/basics/keyspaces/README.md
+++ b/topics/basics/keyspaces/README.md
@@ -17,7 +17,7 @@ You can specify a keyspace to change to by executing a `USE` statement on a conn
 
 ```c
 CassStatement use_statment 
-  = cass_statement_new(cass_string_init("USE keyspace1"), 0);
+  = cass_statement_new("USE keyspace1", 0);
 
 CassFuture* use_future 
   = cass_session_execute(session, use_statement);

--- a/topics/basics/prepared_statements/README.md
+++ b/topics/basics/prepared_statements/README.md
@@ -28,7 +28,7 @@ cass_future_free(prepare_future);
 CassStatement* statement = cass_prepared_bind(prepared);
 
 /* Bind variables by name this time (this can only be done with prepared statements)*/
-cass_statement_bind_string_by_name(statement, "key", cass_string_init("abc"));
+cass_statement_bind_string_by_name(statement, "key", "abc");
 cass_statement_bind_int32_by_name(statement, "value", 123);
 
 /* Execute statement (same a the non-prepared code) */

--- a/topics/security/ssl/README.md
+++ b/topics/security/ssl/README.md
@@ -111,7 +111,7 @@ int load_trusted_cert_file(const char* file, CassSsl* ssl) {
   fclose(in);
 
   // Add the trusted certificate (or chain) to the driver
-  rc = cass_ssl_add_trusted_cert(ssl, cass_string_init2(cert, cert_size));
+  rc = cass_ssl_add_trusted_cert_n(ssl, cert, cert_size);
   if (rc != CASS_OK) {
     fprintf(stderr, "Error loading SSL certificate: %s\n", cass_error_desc(rc));
     free(cert);
@@ -196,7 +196,7 @@ size_t cert_size = 0;
 
 // Load PEM-formatted certificate data and size into cert and cert_size...
 
-rc = cass_ssl_set_cert(ssl, cass_string_init2(cert, cert_size));
+rc = cass_ssl_set_cert_n(ssl, cert, cert_size);
 if (rc != CASS_OK) {
   // Handle error
 }
@@ -210,7 +210,7 @@ const char* key_password = "<key password>";
 
 // Load PEM-formatted private key data and size into key and key_size...
 
-rc = cass_ssl_set_private_key(ssl, cass_string_init2(key, key_size), key_password);
+rc = cass_ssl_set_private_key_n(ssl, key, key_size, key_password, strlen(key_password));
 if (rc != CASS_OK) {
   // Handle error
 }


### PR DESCRIPTION
This function and the corresponding CassString wrapper type were removed
in version 2.0.