### PR TITLE
Adapt Debian packaking to jessie-backports package names.

### DIFF
--- a/packaging/build_deb.sh
+++ b/packaging/build_deb.sh
@@ -22,8 +22,11 @@ files="CMakeLists.txt cmake_uninstall.cmake.in include src"
 libuv_version=$(dpkg -s libuv | grep 'Version' | awk '{ print $2 }')
 
 if [[ -e $libuv_version ]]; then
-  echo "'libuv' required, but not installed"
-  exit 1
+    libuv_version=$(dpkg -s libuv1 | grep 'Version' | awk '{ print $2 }')
+    if [[ -e $libuv_version ]]; then
+	echo "'libuv' required, but not installed"
+	exit 1
+    fi
 fi
 
 echo "Using libuv version $libuv_version"

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,7 @@ Source: cassandra-cpp-driver
 Priority: extra
 Maintainer: Michael Penick <michael.penick@datastax.com>
 Build-Depends: debhelper (>= 9.0.0), dh-exec, cmake, make,
-        libuv-dev (>= 1.0.0),
+        libuv-dev (>= 1.0.0) | libuv1-dev (>= 1.0.0),
         libssl-dev
 Standards-Version: 3.9.2
 Section: libs


### PR DESCRIPTION
To package the cpp-driver on Debian Jessie, the libuv driver from jessie-backports is required. There the library is packaged with the name "libuv1". These two changes adapt the Debian packaking to take the name into consideration.