### PR TITLE
269 - MPMC queue should emit a memory fence on x86/x64

### DIFF
--- a/src/mpmc_queue.hpp
+++ b/src/mpmc_queue.hpp
@@ -132,9 +132,7 @@ public:
   }
 
   static void memory_fence() {
-#if defined(__x86_64__) || defined(_M_X64) || defined(__i386) || defined(_M_IX86)
-    // No fence required becauase compare_exchange_weak() emits "lock cmpxchg" on x86/x64 enforcing total order.
-#elif defined(CASS_USE_BOOST_ATOMIC) || defined(CASS_USE_STD_ATOMIC)
+#if defined(CASS_USE_BOOST_ATOMIC) || defined(CASS_USE_STD_ATOMIC)
     atomic_thread_fence(MEMORY_ORDER_SEQ_CST);
 #endif
   }


### PR DESCRIPTION
The intrinsics implementation already emits a memory fence in the final
store to the sequence in MPMC so it doesn’t require the extra fence.