### PR TITLE
Address::compare() fixed

### DIFF
--- a/src/address.cpp
+++ b/src/address.cpp
@@ -139,12 +139,12 @@ std::string Address::to_string(bool with_port) const {
   return ss.str();
 }
 
-int Address::compare(const Address& a) const {
+std::int64_t Address::compare(const Address& a) const {
   if (family() != a.family()) {
     return family() - a.family();
   }
   if (family() == AF_INET) {
-    return (addr_in()->sin_addr.s_addr - a.addr_in()->sin_addr.s_addr);
+    return (static_cast< std::int64_t >(addr_in()->sin_addr.s_addr) - static_cast< std::int64_t >(a.addr_in()->sin_addr.s_addr));
   } else if (family() == AF_INET6) {
     return memcmp(&(addr_in6()->sin6_addr), &(a.addr_in6()->sin6_addr),
                   sizeof(addr_in6()->sin6_addr));

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -139,12 +139,12 @@ std::string Address::to_string(bool with_port) const {
   return ss.str();
 }
 
-std::int64_t Address::compare(const Address& a) const {
+int64_t Address::compare(const Address& a) const {
   if (family() != a.family()) {
     return family() - a.family();
   }
   if (family() == AF_INET) {
-    return (static_cast< std::int64_t >(addr_in()->sin_addr.s_addr) - static_cast< std::int64_t >(a.addr_in()->sin_addr.s_addr));
+    return (static_cast< int64_t >(addr_in()->sin_addr.s_addr) - static_cast< int64_t >(a.addr_in()->sin_addr.s_addr));
   } else if (family() == AF_INET6) {
     return memcmp(&(addr_in6()->sin6_addr), &(a.addr_in6()->sin6_addr),
                   sizeof(addr_in6()->sin6_addr));

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -20,7 +20,7 @@
 #include "utils.hpp"
 
 #include <uv.h>
-#include <cstdint>
+#include <stdint.h>
 #include <set>
 #include <string.h>
 #include <string>
@@ -69,7 +69,7 @@ public:
 
   std::string to_string(bool with_port = false) const;
 
-  std::int64_t compare(const Address& a) const;
+  int64_t compare(const Address& a) const;
 
 private:
   void init() { memset(&addr_, 0, sizeof(addr_)); }

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -20,6 +20,7 @@
 #include "utils.hpp"
 
 #include <uv.h>
+#include <cstdint>
 #include <set>
 #include <string.h>
 #include <string>
@@ -68,7 +69,7 @@ public:
 
   std::string to_string(bool with_port = false) const;
 
-  int compare(const Address& a) const;
+  std::int64_t compare(const Address& a) const;
 
 private:
   void init() { memset(&addr_, 0, sizeof(addr_)); }


### PR DESCRIPTION
Some IPv4 addresses could not be found in `IOWorker::PoolMap` instance because  `Address::compare()` method was broken on *Windows x64*.