### PR TITLE
Fix compile error in CCMBridge on Windows

### DIFF
--- a/test/ccm_bridge/src/bridge.cpp
+++ b/test/ccm_bridge/src/bridge.cpp
@@ -15,6 +15,7 @@
 */
 #ifdef _WIN32
 // Local execution command
+#include <io.h>
 #define FILENO _fileno
 #define POPEN _popen
 #define PCLOSE _pclose


### PR DESCRIPTION
In contrast to the other functions _read is declared in io.h.