### PR TITLE
Resolve multiple addresses for each domain name.

### DIFF
--- a/src/resolver.hpp
+++ b/src/resolver.hpp
@@ -49,7 +49,7 @@ public:
   bool is_success() { return status_ == SUCCESS; }
   bool is_timed_out() { return status_ == FAILED_TIMED_OUT; }
   Status status() { return status_; }
-  const std::vector<Address>& addresses() const { return addresses_; }
+  const AddressVec& addresses() const { return addresses_; }
   T& data() { return data_; }
 
   static void resolve(uv_loop_t* loop, const std::string& hostname, int port,
@@ -134,7 +134,7 @@ private:
   std::string hostname_;
   int port_;
   Status status_;
-  std::vector<Address> addresses_;
+  AddressVec addresses_;
   T data_;
   Callback cb_;
 };

--- a/src/resolver.hpp
+++ b/src/resolver.hpp
@@ -49,7 +49,7 @@ public:
   bool is_success() { return status_ == SUCCESS; }
   bool is_timed_out() { return status_ == FAILED_TIMED_OUT; }
   Status status() { return status_; }
-  const Address& address() const { return address_; }
+  const std::vector<Address>& addresses() const { return addresses_; }
   T& data() { return data_; }
 
   static void resolve(uv_loop_t* loop, const std::string& hostname, int port,
@@ -84,7 +84,7 @@ private:
 
       if (status != 0) {
         resolver->status_ = FAILED_UNABLE_TO_RESOLVE;
-      } else if (!resolver->address_.init(res->ai_addr)) {
+      } else if (!resolver->init_addresses(res)) {
         resolver->status_ = FAILED_UNSUPPORTED_ADDRESS_FAMILY;
       } else {
         resolver->status_ = SUCCESS;
@@ -104,6 +104,20 @@ private:
   }
 
 private:
+  bool init_addresses(struct addrinfo* res) {
+    bool status = false;
+    do {
+      Address address;
+      if (address.init(res->ai_addr)) {
+        addresses_.push_back(address);
+        status = true;
+      }
+      res = res->ai_next;
+    } while(res);
+    return status;
+  }
+
+private:
   Resolver(const std::string& hostname, int port, const T& data, Callback cb)
       : hostname_(hostname)
       , port_(port)
@@ -120,7 +134,7 @@ private:
   std::string hostname_;
   int port_;
   Status status_;
-  Address address_;
+  std::vector<Address> addresses_;
   T data_;
   Callback cb_;
 };

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -494,8 +494,8 @@ void Session::on_event(const SessionEvent& event) {
 void Session::on_resolve(MultiResolver<Session*>::Resolver* resolver) {
   Session* session = resolver->data()->data();
   if (resolver->is_success()) {
-    std::vector<Address> addresses = resolver->addresses();
-    for (std::vector<Address>::iterator it = addresses.begin(); it != addresses.end(); ++it) {
+    AddressVec addresses = resolver->addresses();
+    for (AddressVec::iterator it = addresses.begin(); it != addresses.end(); ++it) {
       SharedRefPtr<Host> host = session->add_host(*it);
       host->set_hostname(resolver->hostname());
     }

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -494,8 +494,11 @@ void Session::on_event(const SessionEvent& event) {
 void Session::on_resolve(MultiResolver<Session*>::Resolver* resolver) {
   Session* session = resolver->data()->data();
   if (resolver->is_success()) {
-    SharedRefPtr<Host> host = session->add_host(resolver->address());
-    host->set_hostname(resolver->hostname());
+    std::vector<Address> addresses = resolver->addresses();
+    for (std::vector<Address>::iterator it = addresses.begin(); it != addresses.end(); ++it) {
+      SharedRefPtr<Host> host = session->add_host(*it);
+      host->set_hostname(resolver->hostname());
+    }
   } else if (resolver->is_timed_out()) {
     LOG_ERROR("Timed out attempting to resolve address for %s:%d\n",
               resolver->hostname().c_str(), resolver->port());


### PR DESCRIPTION
Resolve multiple addresses for each domain name. Before only one IP was returned even if the domain name resolves to several IP addresses. This is useful if a domain name resolves to all the the client seednodes.

The code is tested but no test is included since it would rely on a nameserver which cannot be _simply_ and reliably provided to an integration test.