### PR TITLE
367 - Fix: Session connect hangs because of "UP" event

### DIFF
--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -248,6 +248,12 @@ void ControlConnection::on_close(Connection* connection) {
 }
 
 void ControlConnection::on_event(EventResponse* response) {
+  // Only process events after an initial set of hosts and schema have been
+  // established. Adding a host from an UP/NEW_NODE event before the initial
+  // set will cause the driver to hang waiting for an invalid pending pool
+  // count.
+  if (state_ != CONTROL_STATE_READY) return;
+
   switch (response->event_type()) {
     case CASS_EVENT_TOPOLOGY_CHANGE: {
       std::string address_str = response->affected_node().to_string();


### PR DESCRIPTION
Adding a connection pool as a result of an event before the driver is
done with its connection process causes the pending pool count to never
decrement to zero. Events are no longer able to add or remove pools
until the control connection ready.