### PR TITLE
Avoid core while extracting error message from future w/NULL response.

### DIFF
--- a/src/future.cpp
+++ b/src/future.cpp
@@ -96,6 +96,7 @@ const CassErrorResult* cass_future_get_error_result(CassFuture* future) {
       static_cast<cass::ResponseFuture*>(future->from());
 
   if (!response_future->is_error()) return NULL;
+  if (!response_future->response()) return NULL;
 
   cass::SharedRefPtr<cass::ErrorResponse> error_result(response_future->response());
   error_result->inc_ref();

--- a/src/future.cpp
+++ b/src/future.cpp
@@ -62,9 +62,8 @@ const CassResult* cass_future_get_result(CassFuture* future) {
 
   if (result) {
     result->decode_first_row();
+    result->inc_ref();
   }
-
-  if (result) result->inc_ref();
 
   return CassResult::to(result.get());
 }

--- a/src/future.cpp
+++ b/src/future.cpp
@@ -64,7 +64,7 @@ const CassResult* cass_future_get_result(CassFuture* future) {
     result->decode_first_row();
   }
 
-  result->inc_ref();
+  if (result) result->inc_ref();
 
   return CassResult::to(result.get());
 }
@@ -82,7 +82,7 @@ const CassPrepared* cass_future_get_prepared(CassFuture* future) {
   if (result && result->kind() == CASS_RESULT_KIND_PREPARED) {
     cass::Prepared* prepared =
         new cass::Prepared(result, response_future->statement, response_future->schema_metadata);
-    prepared->inc_ref();
+    if (prepared) prepared->inc_ref();
     return CassPrepared::to(prepared);
   }
   return NULL;
@@ -96,10 +96,9 @@ const CassErrorResult* cass_future_get_error_result(CassFuture* future) {
       static_cast<cass::ResponseFuture*>(future->from());
 
   if (!response_future->is_error()) return NULL;
-  if (!response_future->response()) return NULL;
 
   cass::SharedRefPtr<cass::ErrorResponse> error_result(response_future->response());
-  error_result->inc_ref();
+  if (error_result) error_result->inc_ref();
   return CassErrorResult::to(error_result.get());
 }
 
@@ -146,17 +145,20 @@ CassError cass_future_custom_payload_item(CassFuture* future,
   }
   cass::SharedRefPtr<cass::Response> response(
         static_cast<cass::ResponseFuture*>(future->from())->response());
-  const cass::Response::CustomPayloadVec& custom_payload
-      = response->custom_payload();
-  if (index >= custom_payload.size()) {
-    return CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+  if (response) {
+    const cass::Response::CustomPayloadVec& custom_payload =
+          response->custom_payload();
+    if (index >= custom_payload.size()) {
+      return CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS;
+    }
+    const cass::Response::CustomPayloadItem& item = custom_payload[index];
+    *name = item.name.data();
+    *name_length = item.name.size();
+    *value = reinterpret_cast<const cass_byte_t*>(item.value.data());
+    *value_size = item.value.size();
+    return CASS_OK;
   }
-  const cass::Response::CustomPayloadItem& item = custom_payload[index];
-  *name = item.name.data();
-  *name_length = item.name.size();
-  *value = reinterpret_cast<const cass_byte_t*>(item.value.data());
-  *value_size = item.value.size();
-  return CASS_OK;
+  return CASS_ERROR_LIB_INTERNAL_ERROR;
 }
 
 } // extern "C"


### PR DESCRIPTION
When attempting to get future error result from future without response, got the following stack trace:
```
#0  0x00007ffff10d5f7d in boost::atomics::detail::base_atomic<int, int, 4u, true>::fetch_add (this=0x8, v=1, order=boost::memory_order_relaxed)
    at include/boost/atomic/detail/gcc-x86.hpp:612
#1  0x00007ffff10d48d8 in cass::Atomic<int>::fetch_add (this=0x8, value=1, order=cass::MEMORY_ORDER_RELAXED)
    at cpp-driver/src/atomic/atomic_boost.hpp:48
#2  0x00007ffff10dd236 in cass::RefCounted<cass::Response>::inc_ref (this=0x8) at cpp-driver/src/ref_counted.hpp:42
#3  0x00007ffff114fcda in cass_future_get_error_result (future=0x7fff780017c0) at cpp-driver/src/future.cpp:101
#4  0x00007ffff6f7b179 in cassutils::buildErrorFromFuture (pFuture=0x7fff780017c0, errorOut="Invalid query") at 
```

