### PR TITLE
CCM branch/tag specification and host argument for examples

### DIFF
--- a/examples/async/async.c
+++ b/examples/async/async.c
@@ -42,9 +42,9 @@ void print_error(CassFuture* future) {
 }
 
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -120,10 +120,15 @@ void insert_into_async(CassSession* session, const char* key) {
   }
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/auth/auth.c
+++ b/examples/auth/auth.c
@@ -102,9 +102,6 @@ int main(int argc, char* argv[]) {
   CassCluster* cluster = cass_cluster_new();
   CassSession* session = cass_session_new();
   char* hosts = "127.0.0.1,127.0.0.2,127.0.0.3";
-  if (argc > 1) {
-    hosts = argv[1];
-  }
 
   /* Setup authentication callbacks and credentials */
   CassAuthenticatorCallbacks auth_callbacks = {
@@ -120,6 +117,9 @@ int main(int argc, char* argv[]) {
   };
 
   /* Add contact points */
+  if (argc > 1) {
+    hosts = argv[1];
+  }
   cass_cluster_set_contact_points(cluster, hosts);
 
   /* Set custom authentication callbacks and credentials */

--- a/examples/auth/auth.c
+++ b/examples/auth/auth.c
@@ -96,11 +96,15 @@ void on_auth_cleanup(CassAuthenticator* auth, void* data) {
    */
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   /* Setup and connect to cluster */
   CassFuture* connect_future = NULL;
   CassCluster* cluster = cass_cluster_new();
   CassSession* session = cass_session_new();
+  char* hosts = "127.0.0.1,127.0.0.2,127.0.0.3";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
 
   /* Setup authentication callbacks and credentials */
   CassAuthenticatorCallbacks auth_callbacks = {
@@ -116,7 +120,7 @@ int main() {
   };
 
   /* Add contact points */
-  cass_cluster_set_contact_points(cluster, "127.0.0.1,127.0.0.2,127.0.0.3");
+  cass_cluster_set_contact_points(cluster, hosts);
 
   /* Set custom authentication callbacks and credentials */
   cass_cluster_set_authenticator_callbacks(cluster,

--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -161,13 +161,14 @@ int main(int argc, char* argv[]) {
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   char* hosts = "127.0.0.1";
+
+  Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
+  Basic output;
+
   if (argc > 1) {
     hosts = argv[1];
   }
   cluster = create_cluster(hosts);
-
-  Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
-  Basic output;
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -49,9 +49,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -156,10 +156,15 @@ CassError select_from_basic(CassSession* session, const char* key, Basic* basic)
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
   Basic output;

--- a/examples/batch/batch.c
+++ b/examples/batch/batch.c
@@ -154,12 +154,13 @@ int main(int argc, char* argv[]) {
   CassFuture* close_future = NULL;
   const CassPrepared* prepared = NULL;
   char* hosts = "127.0.0.1";
+
+  Pair pairs[] = { {"a", "1"}, {"b", "2"}, { NULL, NULL} };
+
   if (argc > 1) {
     hosts = argv[1];
   }
   cluster = create_cluster(hosts);
-
-  Pair pairs[] = { {"a", "1"}, {"b", "2"}, { NULL, NULL} };
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/batch/batch.c
+++ b/examples/batch/batch.c
@@ -46,9 +46,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -148,11 +148,16 @@ CassError insert_into_batch_with_prepared(CassSession* session, const CassPrepar
 }
 
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   const CassPrepared* prepared = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   Pair pairs[] = { {"a", "1"}, {"b", "2"}, { NULL, NULL} };
 

--- a/examples/bind_by_name/bind_by_name.c
+++ b/examples/bind_by_name/bind_by_name.c
@@ -49,9 +49,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -174,14 +174,19 @@ CassError select_from_basic(CassSession* session, const CassPrepared * prepared,
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
   Basic output;
   const CassPrepared* insert_prepared = NULL;
   const CassPrepared* select_prepared = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   const char* insert_query
     = "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";

--- a/examples/bind_by_name/bind_by_name.c
+++ b/examples/bind_by_name/bind_by_name.c
@@ -183,15 +183,16 @@ int main(int argc, char* argv[]) {
   const CassPrepared* insert_prepared = NULL;
   const CassPrepared* select_prepared = NULL;
   char* hosts = "127.0.0.1";
-  if (argc > 1) {
-    hosts = argv[1];
-  }
-  cluster = create_cluster(hosts);
 
   const char* insert_query
     = "INSERT INTO examples.basic (key, bln, flt, dbl, i32, i64) VALUES (?, ?, ?, ?, ?, ?);";
   const char* select_query
     = "SELECT * FROM examples.basic WHERE key = ?";
+
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/callbacks/callbacks.c
+++ b/examples/callbacks/callbacks.c
@@ -79,9 +79,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -211,9 +211,14 @@ void on_select(CassFuture* future, void* data) {
   signal_exit((CassSession*)data);
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   uuid_gen = cass_uuid_gen_new();
 

--- a/examples/collections/collections.c
+++ b/examples/collections/collections.c
@@ -162,14 +162,15 @@ int main(int argc, char* argv[]) {
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   char* hosts = "127.0.0.1";
-  if (argc > 1) {
-    hosts = argv[1];
-  }
-  cluster = create_cluster(hosts);
 
   const char* items[] = { "apple", "orange", "banana", "mango", NULL };
 
   cass_cluster_set_protocol_version(cluster, 2);
+
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/collections/collections.c
+++ b/examples/collections/collections.c
@@ -39,9 +39,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -157,10 +157,15 @@ CassError select_from_collections(CassSession* session, const char* key) {
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   const char* items[] = { "apple", "orange", "banana", "mango", NULL };
 

--- a/examples/date_time/data_time.c
+++ b/examples/date_time/data_time.c
@@ -40,9 +40,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -154,10 +154,15 @@ CassError select_from(CassSession* session, const char* key) {
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/logging/logging.c
+++ b/examples/logging/logging.c
@@ -74,9 +74,6 @@ int main(int argc, char* argv[]) {
   CassSession* session = NULL;
   CassFuture* close_future = NULL;
   char* hosts = "127.0.0.1";
-  if (argc > 1) {
-    hosts = argv[1];
-  }
 
   FILE* log_file = fopen("driver.log", "w+");
   if (log_file == NULL) {
@@ -87,6 +84,9 @@ int main(int argc, char* argv[]) {
   cass_log_set_level(CASS_LOG_INFO);
   cass_log_set_callback(on_log, (void*)log_file);
 
+  if (argc > 1) {
+    hosts = argv[1];
+  }
   cluster = create_cluster(hosts);
   session = cass_session_new();
 

--- a/examples/logging/logging.c
+++ b/examples/logging/logging.c
@@ -39,9 +39,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -69,10 +69,14 @@ void on_log(const CassLogMessage* message, void* data) {
           message->message);
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   CassCluster* cluster = NULL;
   CassSession* session = NULL;
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
 
   FILE* log_file = fopen("driver.log", "w+");
   if (log_file == NULL) {
@@ -83,7 +87,7 @@ int main() {
   cass_log_set_level(CASS_LOG_INFO);
   cass_log_set_callback(on_log, (void*)log_file);
 
-  cluster = create_cluster();
+  cluster = create_cluster(hosts);
   session = cass_session_new();
 
   if (connect_session(session, cluster) != CASS_OK) {

--- a/examples/maps/maps.c
+++ b/examples/maps/maps.c
@@ -44,9 +44,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -163,10 +163,15 @@ CassError select_from_maps(CassSession* session, const char* key) {
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   const Pair items[] = { { "apple", 1 }, { "orange", 2 }, { "banana", 3 }, { "mango", 4 }, { NULL, 0 } };
 

--- a/examples/maps/maps.c
+++ b/examples/maps/maps.c
@@ -168,12 +168,13 @@ int main(int argc, char* argv[]) {
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   char* hosts = "127.0.0.1";
+
+  const Pair items[] = { { "apple", 1 }, { "orange", 2 }, { "banana", 3 }, { "mango", 4 }, { NULL, 0 } };
+
   if (argc > 1) {
     hosts = argv[1];
   }
   cluster = create_cluster(hosts);
-
-  const Pair items[] = { { "apple", 1 }, { "orange", 2 }, { "banana", 3 }, { "mango", 4 }, { NULL, 0 } };
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/named_parameters/named_parameters.c
+++ b/examples/named_parameters/named_parameters.c
@@ -49,9 +49,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -161,12 +161,17 @@ CassError select_from_basic(CassSession* session, const char* key, Basic* basic)
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
   Basic output;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/paging/paging.c
+++ b/examples/paging/paging.c
@@ -41,9 +41,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -167,11 +167,16 @@ void select_from_paging(CassSession* session) {
   cass_statement_free(statement);
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   CassUuidGen* uuid_gen = cass_uuid_gen_new();
-  CassCluster* cluster = create_cluster();
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/perf/perf.c
+++ b/examples/perf/perf.c
@@ -104,9 +104,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   cass_cluster_set_credentials(cluster, "cassandra", "cassandra");
   cass_cluster_set_num_threads_io(cluster, NUM_IO_WORKER_THREADS);
   cass_cluster_set_queue_size_io(cluster, 10000);
@@ -295,19 +295,23 @@ void run_select_queries(void* data) {
   status_notify(&status);
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   int i;
   CassMetrics metrics;
   uv_thread_t threads[NUM_THREADS];
   CassCluster* cluster = NULL;
   CassSession* session = NULL;
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
 
   status_init(&status, NUM_THREADS);
 
   cass_log_set_level(CASS_LOG_INFO);
 
-  cluster = create_cluster();
+  cluster = create_cluster(hosts);
   uuid_gen = cass_uuid_gen_new();
   session = cass_session_new();
 

--- a/examples/prepared/prepared.c
+++ b/examples/prepared/prepared.c
@@ -49,9 +49,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -176,13 +176,18 @@ CassError select_from_basic(CassSession* session, const CassPrepared * prepared,
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   Basic input = { cass_true, 0.001f, 0.0002, 1, 2 };
   Basic output;
   const CassPrepared* prepared = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/examples/schema_meta/schema_meta.c
+++ b/examples/schema_meta/schema_meta.c
@@ -126,11 +126,15 @@ CassError execute_query(CassSession* session, const char* query) {
   return rc;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   CassFuture* connect_future = NULL;
   CassCluster* cluster = cass_cluster_new();
   CassSession* session = cass_session_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cass_cluster_set_contact_points(cluster, hosts);
 
   connect_future = cass_session_connect(session, cluster);
 

--- a/examples/simple/simple.c
+++ b/examples/simple/simple.c
@@ -28,14 +28,18 @@
 #include <stdio.h>
 #include <cassandra.h>
 
-int main() {
+int main(int argc, char* argv[]) {
   /* Setup and connect to cluster */
   CassFuture* connect_future = NULL;
   CassCluster* cluster = cass_cluster_new();
   CassSession* session = cass_session_new();
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
 
   /* Add contact points */
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
 
   /* Provide the cluster object as configuration to connect the session */
   connect_future = cass_session_connect(session, cluster);

--- a/examples/ssl/ssl.c
+++ b/examples/ssl/ssl.c
@@ -62,14 +62,18 @@ int load_trusted_cert_file(const char* file, CassSsl* ssl) {
   return 1;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   /* Setup and connect to cluster */
   CassFuture* connect_future = NULL;
   CassCluster* cluster = cass_cluster_new();
   CassSession* session = cass_session_new();
   CassSsl* ssl = cass_ssl_new();
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
 
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
 
   /* Only verify the certification and not the identity */
   cass_ssl_set_verify_flags(ssl, CASS_SSL_VERIFY_PEER_CERT);
@@ -118,7 +122,7 @@ int main() {
       cass_future_error_message(result_future, &message, &message_length);
       fprintf(stderr, "Unable to run query: '%.*s'\n", (int)message_length,
                                                             message);
-    } 
+    }
 
     cass_statement_free(statement);
     cass_future_free(result_future);

--- a/examples/tuple/tuple.c
+++ b/examples/tuple/tuple.c
@@ -41,9 +41,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -207,10 +207,15 @@ CassError select_from_tuple(CassSession* session) {
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   uuid_gen = cass_uuid_gen_new();
 

--- a/examples/udt/udt.c
+++ b/examples/udt/udt.c
@@ -42,9 +42,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -231,10 +231,15 @@ CassError select_from_udt(CassSession* session) {
   return rc;
 }
 
-int main() {
-  CassCluster* cluster = create_cluster();
+int main(int argc, char* argv[]) {
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   uuid_gen = cass_uuid_gen_new();
 

--- a/examples/uuids/uuids.c
+++ b/examples/uuids/uuids.c
@@ -49,9 +49,9 @@ void print_error(CassFuture* future) {
   fprintf(stderr, "Error: %.*s\n", (int)message_length, message);
 }
 
-CassCluster* create_cluster() {
+CassCluster* create_cluster(const char* hosts) {
   CassCluster* cluster = cass_cluster_new();
-  cass_cluster_set_contact_points(cluster, "127.0.0.1");
+  cass_cluster_set_contact_points(cluster, hosts);
   return cluster;
 }
 
@@ -165,12 +165,17 @@ CassError select_from_log(CassSession* session, const char* key) {
   return rc;
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   CassUuidGen* uuid_gen = cass_uuid_gen_new();
-  CassCluster* cluster = create_cluster();
+  CassCluster* cluster = NULL;
   CassSession* session = cass_session_new();
   CassFuture* close_future = NULL;
   CassUuid uuid;
+  char* hosts = "127.0.0.1";
+  if (argc > 1) {
+    hosts = argv[1];
+  }
+  cluster = create_cluster(hosts);
 
   if (connect_session(session, cluster) != CASS_OK) {
     cass_cluster_free(cluster);

--- a/test/ccm_bridge/data/config.txt
+++ b/test/ccm_bridge/data/config.txt
@@ -13,13 +13,19 @@
 #
 # Uncomment to specify Cassandra version
 ##
-#CASSANDRA_VERSION=3.4
+#CASSANDRA_VERSION=3.7
 ##
 # Flag to determine if Cassandra/DSE version should be obtained from ASF/GitHub
 #
 # Uncomment to specify use of ASF/GitHub download
 ##
 #USE_GIT=false
+##
+# Specific branch/tag to utilize when obtaining from ASF/GitHub
+#
+# Uncomment to specify branch/tag to download
+##
+#BRANCH_TAG=
 ##
 # CCM Deployment Type (local|remote)
 #
@@ -46,7 +52,7 @@
 #
 # Uncomment to specify DSE version
 ##
-#DSE_VERSION=4.8.5
+#DSE_VERSION=4.8.8
 ##
 # CCM DSE Credentials Type (username_password|ini_file)
 #

--- a/test/ccm_bridge/src/bridge.hpp
+++ b/test/ccm_bridge/src/bridge.hpp
@@ -42,10 +42,11 @@ typedef struct _LIBSSH2_CHANNEL LIBSSH2_CHANNEL;
 #endif
 
 // Default values
-#define DEFAULT_CASSANDRA_VERSION CassVersion("3.4")
-#define DEFAULT_DSE_VERSION DseVersion("4.8.5")
+#define DEFAULT_CASSANDRA_VERSION CassVersion("3.7")
+#define DEFAULT_DSE_VERSION DseVersion("4.8.8")
 #define DEFAULT_USE_GIT false
 #define DEFAULT_USE_DSE false
+#define DEFAULT_DSE_WORKLOAD DSE_WORKLOAD_CASSANDRA
 #define DEFAULT_CLUSTER_PREFIX "cpp-driver"
 #define DEFAULT_DSE_CREDENTIALS DseCredentialsType::USERNAME_PASSWORD
 #define DEFAULT_DEPLOYMENT DeploymentType::LOCAL
@@ -139,9 +140,15 @@ namespace CCM {
      *                otherwise (default: DEFAULT_USE_GIT). Prepends
      *                `cassandra-` to version when creating cluster through CCM
      *                if using Cassandra; otherwise passes version information
-     *                to CCM for git download of DSE.
+     *                to CCM for git download of DSE. Set branch_tag to
+     *                override default action.
+     * @param branch_tag Branch/Tag to use when use_git is enabled
+     *                   (default: Empty). This value is independent of the
+     *                   version specified.
      * @param use_dse True if CCM should load DSE for provided version; false
      *               otherwise (default: DEFAULT_USE_DSE)
+     * @param dse_workload DSE workload to utilize
+     *                     (default: DSE_WORKLOAD_CASSANDRA)
      * @param cluster_prefix Prefix to use when creating a cluster name
      *                       (default: DEFAULT_CLUSTER_PREFIX)
      * @param dse_credentials_type Username|Password/INI file credentials
@@ -170,7 +177,9 @@ namespace CCM {
      */
     Bridge(CassVersion cassandra_version = DEFAULT_CASSANDRA_VERSION,
       bool use_git = DEFAULT_USE_GIT,
+      const std::string& branch_tag = "",
       bool use_dse = DEFAULT_USE_DSE,
+      DseWorkload dse_workload = DSE_WORKLOAD_CASSANDRA,
       const std::string& cluster_prefix = DEFAULT_CLUSTER_PREFIX,
       DseCredentialsType dse_credentials_type = DEFAULT_DSE_CREDENTIALS,
       const std::string& dse_username = "",
@@ -586,9 +595,17 @@ namespace CCM {
      */
     bool use_git_;
     /**
+     * Branch/Tag to retrieve from ASF/GitHub
+     */
+    std::string branch_tag_;
+    /**
      * Flag to determine if DSE is being used
      */
     bool use_dse_;
+    /**
+     * Workload to apply to the DSE cluster
+     */
+    DseWorkload dse_workload_;
     /**
      * Cluster prefix to apply to cluster name during create command
      */


### PR DESCRIPTION
- Sometimes branch/tags do not conform to `cassandra-<version_number>` and when requesting git versions the ability to force an exact branch/tag was not available; this corrects that issue.
- Driver example contact points are no longer hardcoded `127.0.0.1`, can be specified via command line