### PR TITLE
token aware routing broken + code complexity of map_replicas too high with vnodes

### DIFF
--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -519,6 +519,7 @@ void ControlConnection::on_query_meta_schema(ControlConnection* control_connecti
 
   Session* session = control_connection->session_;
 
+  // this clears token map and breaks token aware routing
   session->metadata().clear_and_update_back();
 
   bool is_initial_connection = (control_connection->state_ == CONTROL_STATE_NEW);
@@ -616,6 +617,7 @@ void ControlConnection::refresh_node_info(SharedRefPtr<Host> host,
   }
 }
 
+  // duplicate code with on_refresh_node_info_all
 void ControlConnection::on_refresh_node_info(ControlConnection* control_connection,
                                              const RefreshNodeData& data,
                                              Response* response) {
@@ -644,6 +646,7 @@ void ControlConnection::on_refresh_node_info(ControlConnection* control_connecti
   }
 }
 
+  // duplicate code with on_refresh_node_info_all and query_host
 void ControlConnection::on_refresh_node_info_all(ControlConnection* control_connection,
                                                  const RefreshNodeData& data,
                                                  Response* response) {

--- a/src/replication_strategy.cpp
+++ b/src/replication_strategy.cpp
@@ -101,6 +101,7 @@ static DCRackMap racks_in_dcs(const TokenHostMap& token_hosts) {
   return racks;
 }
 
+  // @TODO: this method is unreadable, and seems too complex for what it does
 void NetworkTopologyStrategy::tokens_to_replicas(const TokenHostMap& primary, TokenReplicaMap* output) const {
   DCRackMap racks = racks_in_dcs(primary);
 

--- a/src/token_map.cpp
+++ b/src/token_map.cpp
@@ -140,6 +140,10 @@ void TokenMap::update_host(SharedRefPtr<Host>& host, const TokenStringList& toke
     token_map_[partitioner_->token_from_string_ref(*i)] = host;
   }
   mapped_addresses_.insert(host->address());
+  // This should not be done for every host, 
+  // it should be done only once at the end of the row/node loop when getting schema , 
+  // to lower the cost/complexity
+  // it takes >200ms on the client a vnode cluster of 10 nodes, so if you run it 10 times => 2s
   map_replicas();
 }
 


### PR DESCRIPTION
- token aware routing is broken
- complexity of map_replicas is too high (proportionnal to number of tokens) and leads to timeout on reconnect of control connection, if timeout is set at <3s for a cluster of >10 nodes with vnodes activated.