### PR TITLE
Fix version check in schema_metadata/lookup test

### DIFF
--- a/test/integration_tests/src/test_schema_metadata.cpp
+++ b/test/integration_tests/src/test_schema_metadata.cpp
@@ -1426,7 +1426,7 @@ BOOST_AUTO_TEST_CASE(frozen_types) {
  * @expected_result UDA and UDF can be looked up correctly
  */
 BOOST_AUTO_TEST_CASE(lookup) {
-  if (version < "2.1.0") return;
+  if (version < "2.2.0") return;
 
   test_utils::execute_query(session, "CREATE KEYSPACE lookup WITH replication = "
     "{ 'class' : 'SimpleStrategy', 'replication_factor' : 3 }");


### PR DESCRIPTION
The comment of the test states this test is meant for Cassandra 2.2+ yet the check makes it run against version 2.1 as well.