### PR TITLE
Minor fixes in CppDriver.cmake

### DIFF
--- a/cmake/modules/CppDriver.cmake
+++ b/cmake/modules/CppDriver.cmake
@@ -135,9 +135,9 @@ macro(CassUseBoost)
 
   # Determine if Boost components are available for test executables
   if(CASS_BUILD_UNIT_TESTS OR CASS_BUILD_INTEGRATION_TESTS)
-    find_package(Boost ${CASS_MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem log log_setup system regex thread unit_test_framework)
+    find_package(Boost ${CASS_MINIMUM_BOOST_VERSION} COMPONENTS chrono system thread unit_test_framework)
     if(NOT Boost_FOUND)
-      message(FATAL_ERROR "Boost [chrono, date_time, filesystem, log, log_setup, system, regex, thread, and unit_test_framework] are required to build tests")
+      message(FATAL_ERROR "Boost [chrono, system, thread, and unit_test_framework] are required to build tests")
     endif()
 
     # Assign Boost include and libraries

--- a/cmake/modules/CppDriver.cmake
+++ b/cmake/modules/CppDriver.cmake
@@ -375,7 +375,6 @@ macro(CassSetCompilerFlags)
     add_definitions(/wd4800) # Performance warning due to automatic compiler casting from int to bool
 
     # Add preprocessor definitions for proper compilation
-    add_definitions(-D_WIN32_WINNT=0x0501)      # Required for winsock (pre Windows XP wspiapi.h only)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)  # Remove warnings for not using safe functions (TODO: Fix codebase to be more secure for Visual Studio)
     add_definitions(-DNOMINMAX)                 # Does not define min/max macros
 


### PR DESCRIPTION
As far as I can tell boost date_time, filesystem, log / log_setup and regex are not used anywhere.
I was able to build the driver after removing the components from find_package. 