### PR TITLE
Ensure that the CMAKE_MODULE_PATH is set correctly even if this project is transitively linked

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.6.4)
 
 # Ensure functions/modules are available
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/modules/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/")
 
 set(PROJECT_NAME_STR cassandra)
 set(PROJECT_LIB_NAME ${PROJECT_NAME_STR})


### PR DESCRIPTION
In the case that the cpp-driver is built as a transitively linked library
(aka embedded in another CMake project), the module path will be augmented
relative to the project root instead of this project.