### PR TITLE
Document how to run unit and integration tests

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -22,6 +22,10 @@ sections:
       EXTRACT_ALL = YES
       INLINE_SOURCES = NO
       ALIASES = cassandra{1}="<b>Requires Cassandra:</b> \1"
+checks:
+  external_links:
+    exclude:
+    - 'https://ci.appveyor.com/api/projects/status/ec0x0vuk59as28r6/branch/master'
 rewrites:
   - http://datastax.github.io/cpp-driver/: /
   - https://datastax.github.io/cpp-driver/: /

--- a/topics/testing/README.md
+++ b/topics/testing/README.md
@@ -1,6 +1,21 @@
 # Testing
 Before proceeding ensure the tests were built using the [build procedures].
 
+Both unit and integration tests use [Boost.Test](http://www.boost.org/doc/libs/1_62_0/libs/test/doc/html/index.html)
+and are packaged up into the `test/unit_tests/cassandra_unit_tests` and
+`test/integration_tests/cassandra_integration_tests` binaries, respectively. Run the test program with desired options:
+
+```
+# Run all integration tests
+test/integration_tests/cassandra_integration_tests
+
+# List all unit test suites and the names of the tests they contain
+test/unit_tests/cassandra_unit_tests --list_content
+
+# Run a particular suite
+test/unit_tests/cassandra_unit_tests -t blacklist_lb
+```
+
 Each test performs a [setup](#setup-cassandra), [execute](#execute-test), and
 [teardown](#teardown-cassandra). This ensures that each test has a clean and
 consistent run against the Apache Cassandra instance during the execution
@@ -41,7 +56,7 @@ cluster may be as large as nine nodes depending on the test being performed.
 
 ```
 
-### Execute Test
+#### Execute Test
 ```ditaa
                 /-----------\                                  /------------\
                 | Unit Test |         Perform Test             | C++ Driver |
@@ -80,7 +95,7 @@ cluster may be as large as nine nodes depending on the test being performed.
                                    \--------------------/
 ```
 
-### Teardown Cassandra
+#### Teardown Cassandra
 ```ditaa
 /------------------\               /------------\                  /-------------\                 /----------\
 | Integration Test |               | CCM Bridge |                  | CCM Machine |                 | CCM Tool |

--- a/topics/testing/README.md
+++ b/topics/testing/README.md
@@ -1,20 +1,12 @@
 # Testing
 Before proceeding ensure the tests were built using the [build procedures].
 
-Both unit and integration tests use [Boost.Test](http://www.boost.org/doc/libs/1_62_0/libs/test/doc/html/index.html)
-and are packaged up into the `test/unit_tests/cassandra_unit_tests` and
-`test/integration_tests/cassandra_integration_tests` binaries, respectively. Run the test program with desired options:
+Both unit and integration tests use [Boost.Test](http://www.boost.org/doc/libs/1_62_0/libs/test/doc/html/index.html).
 
-```
-# Run all integration tests
-test/integration_tests/cassandra_integration_tests
+Integration tests rely on [Cassandra Cluster Manager (CCM)](ccm) to be installed and a [configuration file](configuration)
+in the working directory where tests are executed.
 
-# List all unit test suites and the names of the tests they contain
-test/unit_tests/cassandra_unit_tests --list_content
-
-# Run a particular suite
-test/unit_tests/cassandra_unit_tests -t blacklist_lb
-```
+Details for running unit and integration tests can be found [here](running).
 
 Each test performs a [setup](#setup-cassandra), [execute](#execute-test), and
 [teardown](#teardown-cassandra). This ensures that each test has a clean and

--- a/topics/testing/running/README.md
+++ b/topics/testing/running/README.md
@@ -2,8 +2,17 @@
 
 ## Unit Testing
 The unit tests do not require any additional setup or configuration. Simply run
-the `cassandra_unit_tests` executable. Unit tests are used to ensure the
-functionality of internal components and don't require an instance of Cassandra
+the `cassandra_unit_tests` executable. 
+
+This executable can be found in the
+`test/unit_tests` directory under the `build` directory on Unix platforms. The `build`
+directory is typically the current working directory when you run unit tests since that
+is the directory where the build was launched from.
+
+The `cassandra_unit_tests` executable is located in the `driver\test\unit_tests\<build flavor>` directory on
+Windows. `<build flavor>` is either `Release` or `Debug`.
+
+Unit tests are used to ensure the functionality of internal components and don't require an instance of Cassandra
 to be running.
 
 ## Integration Testing
@@ -12,32 +21,48 @@ The integration tests require a machine (local or remote) with Secure Shell
 tests rely on [Cassandra Cluster Manager (CCM)] and
 cannot run successfully if this dependency is not met. Once the [configuration]
 has been completed the integration tests can be run by executing the
-`cassandra_integration_tests` executable. Integration tests are used to ensure
-the functionality of the driver's API and/or the interaction of multiple
+`cassandra_integration_tests` executable. 
+
+This executable can be found in the `test/integration_tests` directory under the `build`
+directory on Unix platforms. The `build` directory is typically the current working directory
+when you run unit tests since that is the directory where the build was launched from.
+
+The `cassandra_integration_tests` executable is located in the
+`driver\test\integration_tests\<build flavor>` directory on Windows. `<build flavor>` is
+either `Release` or `Debug`.
+
+Integration tests are used to ensure the functionality of the driver's API and/or the interaction of multiple
 internal components.
 
-### Running Tests Individually
-Running the integration test executable without any arguments will start all
-of the integration tests in sequence (one after another). The Boost Test
+## Running Tests Individually
+Running the unit or integration test executable without any arguments will start all
+of the tests in sequence (one after another). The Boost Test
 framework with which the integration and unit tests are compiled come with a
-filter argument that allow for individual test execution. Using the
-`--run_test` argument supplying the test suite and case will execute a single
+filter argument that allows for individual test execution. Using the
+`--run_test` (or `-t` short option) argument, supplying the test suite and case will execute a single
 test.
 
-#### Example
+### Example
 The example below shows how to execute the `simple` test case in the `async`
-test suite.
+test suite of the integration tests.
 
 ```bash
-cassandra_integration_tests --run_test=async/simple
+./test/integration_tests/cassandra_integration_tests --run_test=async/simple
 ````
 
-To run all of the test cases in the `async` suite wildcards can be used in
+To run all of the test cases in the `async` suite, wildcards can be used in
 conjunction with the `run_test` argument
 
 ```bash
-cassandra_integration_tests --run_test=async/*
+./test/integration_tests/cassandra_integration_tests -t async/*
 ```
+
+Equivalently, without wildcards all test cases within the suite run:
+
+```bash
+./test/integration_tests/cassandra_integration_tests -t async
+```
+
 
 [Cassandra Cluster Manager (CCM)]: http://datastax.github.io/cpp-driver/topics/testing/ccm/
 [configuration]: http://datastax.github.io/cpp-driver/topics/testing/configuration/


### PR DESCRIPTION
* Update docs.yaml to exclude an appveyor url from external link checking. The link is good, but documentor erroneously thinks the link is bad.