### PR TITLE
CPP-433 - Request metrics returning zero percentiles

### DIFF
--- a/src/metrics.hpp
+++ b/src/metrics.hpp
@@ -427,6 +427,7 @@ public:
         hdr_histogram* from = histograms_[inactive_index];
         phaser_.flip_phase();
         hdr_add(to, from);
+        hdr_reset(from);
       }
 
     private:


### PR DESCRIPTION
Histogram metrics were incorrectly counting the same values repeatedly.