### PR TITLE
CPP-434

### DIFF
--- a/examples/duration/duration.c
+++ b/examples/duration/duration.c
@@ -74,7 +74,7 @@ CassError execute_query(CassSession* session, const char* query) {
   return rc;
 }
 
-CassError insert_into(CassSession* session, const char* key, cass_int64_t months, cass_int64_t days, cass_int64_t nanos) {
+CassError insert_into(CassSession* session, const char* key, cass_int32_t months, cass_int32_t days, cass_int32_t nanos) {
   CassError rc = CASS_OK;
   CassStatement* statement = NULL;
   CassFuture* future = NULL;
@@ -123,11 +123,11 @@ CassError select_from(CassSession* session, const char* key) {
     CassIterator* iterator = cass_iterator_from_result(result);
 
     if (cass_iterator_next(iterator)) {
-      cass_int64_t months, days, nanos;
+      cass_int32_t months, days, nanos;
       const CassRow* row = cass_iterator_get_row(iterator);
 
       cass_value_get_duration(cass_row_get_column(row, 0), &months, &days, &nanos);
-      printf("months: %lld  days: %lld  nanos: %lld\n", months, days, nanos);
+      printf("months: %d  days: %d  nanos: %d\n", months, days, nanos);
     }
 
     cass_result_free(result);

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -4958,9 +4958,9 @@ cass_statement_bind_decimal_by_name_n(CassStatement* statement,
 CASS_EXPORT CassError
 cass_statement_bind_duration(CassStatement* statement,
                              size_t index,
-                             cass_int64_t months,
-                             cass_int64_t days,
-                             cass_int64_t nanos);
+                             cass_int32_t months,
+                             cass_int32_t days,
+                             cass_int32_t nanos);
 
 /**
  * Binds a "duration" to all the values with the specified name.
@@ -4979,9 +4979,9 @@ cass_statement_bind_duration(CassStatement* statement,
 CASS_EXPORT CassError
 cass_statement_bind_duration_by_name(CassStatement* statement,
                                      const char* name,
-                                     cass_int64_t months,
-                                     cass_int64_t days,
-                                     cass_int64_t nanos);
+                                     cass_int32_t months,
+                                     cass_int32_t days,
+                                     cass_int32_t nanos);
 
 /**
  * Same as cass_statement_bind_duration_by_name(), but with lengths for string
@@ -5005,9 +5005,9 @@ CASS_EXPORT CassError
 cass_statement_bind_duration_by_name_n(CassStatement* statement,
                                        const char* name,
                                        size_t name_length,
-                                       cass_int64_t months,
-                                       cass_int64_t days,
-                                       cass_int64_t nanos);
+                                       cass_int32_t months,
+                                       cass_int32_t days,
+                                       cass_int32_t nanos);
 
 /**
  * Bind a "list", "map" or "set" to a query or bound statement at the
@@ -6178,9 +6178,9 @@ cass_collection_append_decimal(CassCollection* collection,
  */
 CASS_EXPORT CassError
 cass_collection_append_duration(CassCollection* collection,
-                                cass_int64_t months,
-                                cass_int64_t days,
-                                cass_int64_t nanos);
+                                cass_int32_t months,
+                                cass_int32_t days,
+                                cass_int32_t nanos);
 
 /**
  * Appends a "list", "map" or "set" to the collection.
@@ -6615,9 +6615,9 @@ cass_tuple_set_decimal(CassTuple* tuple,
 CASS_EXPORT CassError
 cass_tuple_set_duration(CassTuple* tuple,
                         size_t index,
-                        cass_int64_t months,
-                        cass_int64_t days,
-                        cass_int64_t nanos);
+                        cass_int32_t months,
+                        cass_int32_t days,
+                        cass_int32_t nanos);
 
 /**
  * Sets a "list", "map" or "set" in a tuple at the specified index.
@@ -7648,9 +7648,9 @@ cass_user_type_set_decimal_by_name_n(CassUserType* user_type,
 CASS_EXPORT CassError
 cass_user_type_set_duration(CassUserType* user_type,
                             size_t index,
-                            cass_int64_t months,
-                            cass_int64_t days,
-                            cass_int64_t nanos);
+                            cass_int32_t months,
+                            cass_int32_t days,
+                            cass_int32_t nanos);
 
 /**
  * Sets "duration" in a user defined type at the specified name.
@@ -7669,9 +7669,9 @@ cass_user_type_set_duration(CassUserType* user_type,
 CASS_EXPORT CassError
 cass_user_type_set_duration_by_name(CassUserType* user_type,
                                     const char* name,
-                                    cass_int64_t months,
-                                    cass_int64_t days,
-                                    cass_int64_t nanos);
+                                    cass_int32_t months,
+                                    cass_int32_t days,
+                                    cass_int32_t nanos);
 
 /**
  * Same as cass_user_type_set_duration_by_name(), but with lengths for string
@@ -7695,9 +7695,9 @@ CASS_EXPORT CassError
 cass_user_type_set_duration_by_name_n(CassUserType* user_type,
                                       const char* name,
                                       size_t name_length,
-                                      cass_int64_t months,
-                                      cass_int64_t days,
-                                      cass_int64_t nanos);
+                                      cass_int32_t months,
+                                      cass_int32_t days,
+                                      cass_int32_t nanos);
 
 /**
  * Sets a "list", "map" or "set" in a user defined type at the
@@ -9187,9 +9187,9 @@ cass_value_get_decimal(const CassValue* value,
  */
 CASS_EXPORT CassError
 cass_value_get_duration(const CassValue* value,
-                        cass_int64_t* months,
-                        cass_int64_t* days,
-                        cass_int64_t* nanos);
+                        cass_int32_t* months,
+                        cass_int32_t* days,
+                        cass_int32_t* nanos);
 
 /**
  * Gets the type of the specified value.

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -79,7 +79,7 @@ CASS_COLLECTION_APPEND(decimal,
                        THREE_PARAMS_(const cass_byte_t* varint, size_t varint_size, int scale),
                        cass::CassDecimal(varint, varint_size, scale))
 CASS_COLLECTION_APPEND(duration,
-                       THREE_PARAMS_(cass_int64_t months, cass_int64_t days, cass_int64_t nanos),
+                       THREE_PARAMS_(cass_int32_t months, cass_int32_t days, cass_int32_t nanos),
                        cass::CassDuration(months, days, nanos))
 
 #undef CASS_COLLECTION_APPEND

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -171,7 +171,7 @@ CASS_STATEMENT_BIND(decimal,
                     THREE_PARAMS_(const cass_byte_t* varint, size_t varint_size, int scale),
                     cass::CassDecimal(varint, varint_size, scale))
 CASS_STATEMENT_BIND(duration,
-                    THREE_PARAMS_(cass_int64_t months, cass_int64_t days, cass_int64_t nanos),
+                    THREE_PARAMS_(cass_int32_t months, cass_int32_t days, cass_int32_t nanos),
                     cass::CassDuration(months, days, nanos))
 
 #undef CASS_STATEMENT_BIND

--- a/src/tuple.cpp
+++ b/src/tuple.cpp
@@ -74,7 +74,7 @@ CASS_TUPLE_SET(decimal,
                THREE_PARAMS_(const cass_byte_t* varint, size_t varint_size, int scale),
                cass::CassDecimal(varint, varint_size, scale))
 CASS_TUPLE_SET(duration,
-               THREE_PARAMS_(cass_int64_t months, cass_int64_t days, cass_int64_t nanos),
+               THREE_PARAMS_(cass_int32_t months, cass_int32_t days, cass_int32_t nanos),
                cass::CassDuration(months, days, nanos))
 
 #undef CASS_TUPLE_SET

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -63,15 +63,15 @@ struct CassDecimal {
 };
 
 struct CassDuration {
-  CassDuration(cass_int64_t months,
-               cass_int64_t days,
-               cass_int64_t nanos)
+  CassDuration(cass_int32_t months,
+               cass_int32_t days,
+               cass_int32_t nanos)
     : months(months)
     , days(days)
     , nanos(nanos) { }
-  cass_int64_t months;
-  cass_int64_t days;
-  cass_int64_t nanos;
+  cass_int32_t months;
+  cass_int32_t days;
+  cass_int32_t nanos;
 };
 
 } // namespace cass

--- a/src/user_type_value.cpp
+++ b/src/user_type_value.cpp
@@ -79,7 +79,7 @@ CASS_USER_TYPE_SET(decimal,
                    THREE_PARAMS_(const cass_byte_t* varint, size_t varint_size, int scale),
                    cass::CassDecimal(varint, varint_size, scale))
 CASS_USER_TYPE_SET(duration,
-                   THREE_PARAMS_(cass_int64_t months, cass_int64_t days, cass_int64_t nanos),
+                   THREE_PARAMS_(cass_int32_t months, cass_int32_t days, cass_int32_t nanos),
                    cass::CassDuration(months, days, nanos))
 
 #undef CASS_USER_TYPE_SET

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -179,9 +179,9 @@ static const cass_byte_t* decode_vint(const cass_byte_t* input, const cass_byte_
   return input;
 }
 
-CassError cass_value_get_duration(const CassValue* value, cass_int64_t* months, cass_int64_t* days, cass_int64_t* nanos)
+CassError cass_value_get_duration(const CassValue* value, cass_int32_t* months, cass_int32_t* days, cass_int32_t* nanos)
 {
-  cass_int64_t *outs[3];
+  cass_int32_t *outs[3];
   int ctr;
   size_t data_size = 0;
   const cass_byte_t* cur_byte = NULL;
@@ -199,10 +199,11 @@ CassError cass_value_get_duration(const CassValue* value, cass_int64_t* months, 
   end = cur_byte + data_size;
 
   for (ctr = 0; ctr < 3 && cur_byte != end; ++ctr) {
-    cur_byte = decode_vint(cur_byte, end, outs[ctr]);
+    cass_int64_t decoded = 0;
+    cur_byte = decode_vint(cur_byte, end, &decoded);
     if (cur_byte == NULL)
       return CASS_ERROR_LIB_BAD_PARAMS;
-    *outs[ctr] = cass::decode_zig_zag(*outs[ctr]);
+    *outs[ctr] = (cass_int32_t) cass::decode_zig_zag(decoded);
   }
 
   if (ctr < 3) {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -203,7 +203,7 @@ CassError cass_value_get_duration(const CassValue* value, cass_int32_t* months, 
     cur_byte = decode_vint(cur_byte, end, &decoded);
     if (cur_byte == NULL)
       return CASS_ERROR_LIB_BAD_PARAMS;
-    *outs[ctr] = (cass_int32_t) cass::decode_zig_zag(decoded);
+    *outs[ctr] = static_cast<cass_int32_t>(cass::decode_zig_zag(decoded));
   }
 
   if (ctr < 3) {

--- a/test/integration_tests/src/test_datatypes.cpp
+++ b/test/integration_tests/src/test_datatypes.cpp
@@ -150,10 +150,10 @@ BOOST_AUTO_TEST_CASE(read_write_primitives) {
     value = CassDuration(1, 2, 3);
     insert_value<CassDuration>(CASS_VALUE_TYPE_DURATION, value);
 
-    value = CassDuration((1ULL << 63) - 1, (1ULL << 63) - 1, (1ULL << 63) - 1);
+    value = CassDuration((1ULL << 31) - 1, (1ULL << 31) - 1, (1ULL << 31) - 1);
     insert_value<CassDuration>(CASS_VALUE_TYPE_DURATION, value);
 
-    value = CassDuration(1LL << 63, 1LL << 63, 1LL << 63);
+    value = CassDuration(1LL << 31, 1LL << 31, 1LL << 31);
     insert_value<CassDuration>(CASS_VALUE_TYPE_DURATION, value);
   }
 

--- a/test/integration_tests/src/test_utils.hpp
+++ b/test/integration_tests/src/test_utils.hpp
@@ -88,11 +88,11 @@ struct CassDuration {
     : months(0)
     , days(0)
     , nanos(0) {}
-  CassDuration(cass_int64_t months, cass_int64_t days, cass_int64_t nanos)
+  CassDuration(cass_int32_t months, cass_int32_t days, cass_int32_t nanos)
     : months(months), days(days), nanos(nanos) {}
-  cass_int64_t months;
-  cass_int64_t days;
-  cass_int64_t nanos;
+  cass_int32_t months;
+  cass_int32_t days;
+  cass_int32_t nanos;
 };
 
 struct CassDate {

--- a/test/unit_tests/src/test_value.cpp
+++ b/test/unit_tests/src/test_value.cpp
@@ -55,7 +55,7 @@ TEST_TYPE(inet, CassInet)
 
 BOOST_AUTO_TEST_CASE(bad_duration)
 {
-  cass_int64_t months, days, nanos;
+  cass_int32_t months, days, nanos;
   BOOST_CHECK_EQUAL(cass_value_get_duration(s_text_value, &months, &days, &nanos), CASS_ERROR_LIB_INVALID_VALUE_TYPE);
 }
 


### PR DESCRIPTION
Update api, tests, docs, examples to use 32-bit int's for Duration attributes.