### PR TITLE
Add missing include for MSVC15

### DIFF
--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -26,6 +26,10 @@
 #include <string.h>
 #include <vector>
 
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 namespace cass {
 
 class BufferPiece;


### PR DESCRIPTION
The _BitScanReverse functions now require intrin.h to be included.