### PR TITLE
rebuild token map on new node

### DIFF
--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -279,11 +279,7 @@ void ControlConnection::on_event(EventResponse* response) {
       switch (response->topology_change()) {
         case EventResponse::NEW_NODE: {
           LOG_INFO("New node %s added", address_str.c_str());
-          SharedRefPtr<Host> host = session_->get_host(response->affected_node());
-          if (!host) {
-            host = session_->add_host(response->affected_node());
-            refresh_node_info(host, true, true);
-          }
+          query_meta_hosts();
           break;
         }
 


### PR DESCRIPTION
I know this solution is not acceptable, but I noticed that rebuilding the tokens map instead of updating it was faster and less CPU consuming when adding a node to a cluster of more than 40 nodes and 10 keyspaces.