### PR TITLE
CPP-473/CPP-502: Correcting exported symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c++
+dist: trusty
 sudo: false
 compiler:
   - clang
@@ -13,53 +14,74 @@ cache:
     - ${HOME}/dependencies
 env:
   global:
-    - BOOST_VERSION=1.63.0
-    - BOOST_FILE_VERSION=1_63_0
+    - BOOST_VERSION=1.64.0
+    - BOOST_FILE_VERSION=1_64_0
+    - PROCS=2
   matrix:
     - LIBUV_VERSION=0.10.x EXACT_LIBUV_VERSION=0.10.37
-    - LIBUV_VERSION=1.x EXACT_LIBUV_VERSION=1.11.0
+    - LIBUV_VERSION=1.x EXACT_LIBUV_VERSION=1.14.0
 install:
   - if [ ! -d "${HOME}/dependencies/libuv-${LIBUV_VERSION}" ]; then
-      wget -q http://dist.libuv.org/dist/v${EXACT_LIBUV_VERSION}/libuv-v${EXACT_LIBUV_VERSION}.tar.gz;
+      wget -q --no-check-certificate http://dist.libuv.org/dist/v${EXACT_LIBUV_VERSION}/libuv-v${EXACT_LIBUV_VERSION}.tar.gz;
       tar xzf libuv-v${EXACT_LIBUV_VERSION}.tar.gz;
-      cd libuv-v${EXACT_LIBUV_VERSION};
-      if [ "${LIBUV_VERSION}" == "0.10.x" ]; then
-        make -j2;
-        mkdir -p ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
-        cp libuv* ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
-        cp -r include ${HOME}/dependencies/libuv-${LIBUV_VERSION};
-        cd ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
-        ln -s libuv.so libuv.so.0.10;
-        cd - 2&> /dev/null;
-      fi;
-      if [ "${LIBUV_VERSION}" == "1.x" ]; then
-        sh autogen.sh;
-        ./configure --prefix=${HOME}/dependencies/libuv-${LIBUV_VERSION};
-        make -j2 install;
-      fi;
-      cd - 2&> /dev/null
+      (
+        cd libuv-v${EXACT_LIBUV_VERSION};
+        if [ "${LIBUV_VERSION}" == "0.10.x" ]; then
+          make -j${PROCS};
+          mkdir -p ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
+          cp libuv* ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
+          cp -r include ${HOME}/dependencies/libuv-${LIBUV_VERSION};
+          (
+            cd ${HOME}/dependencies/libuv-${LIBUV_VERSION}/lib;
+            ln -s libuv.so libuv.so.0.10;
+          )
+        elif [ "${LIBUV_VERSION}" == "1.x" ]; then
+          sh autogen.sh;
+          ./configure --prefix=${HOME}/dependencies/libuv-${LIBUV_VERSION};
+          make -j${PROCS} install;
+        fi;
+      )
     else echo "Using Cached libuv v${LIBUV_VERSION}. Dependency does not need to be re-compiled";
     fi
   - if [ ! -d "${HOME}/dependencies/boost_${BOOST_FILE_VERSION}" ]; then
-      wget -q http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_FILE_VERSION}.tar.gz/download -O boost_${BOOST_FILE_VERSION}.tar.gz;
+      wget -q --no-check-certificate http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_FILE_VERSION}.tar.gz/download -O boost_${BOOST_FILE_VERSION}.tar.gz;
       tar xzf boost_${BOOST_FILE_VERSION}.tar.gz;
-      cd boost_${BOOST_FILE_VERSION};
-      ./bootstrap.sh --with-libraries=atomic,chrono,system,thread,test --prefix=${HOME}/dependencies/boost_${BOOST_FILE_VERSION};
-      ./b2 -j2 install;
-      cd - 2&> /dev/null;
+      (
+        cd boost_${BOOST_FILE_VERSION};
+        ./bootstrap.sh --with-libraries=chrono,system,thread,test --prefix=${HOME}/dependencies/boost_${BOOST_FILE_VERSION};
+        ./b2 -j${PROCS} install;
+      )
     else echo "Using Cached Boost v${BOOST_VERSION}. Dependency does not need to be re-compiled";
     fi
-  - cd ${TRAVIS_BUILD_DIR}
 before_script:
   - EXTRA_CXX_FLAGS=
   - EXTRA_C_FLAGS=
-  - USE_BOOST_ATOMIC=OFF
   - if [ "$CXX" == "clang++" ]; then
       EXTRA_CXX_FLAGS="-Wno-unknown-warning-option -Wno-gnu-folding-constant -Wno-sign-compare";
       EXTRA_C_FLAGS="-Wno-unknown-warning-option";
-      USE_BOOST_ATOMIC=ON;
     fi
-  - CFLAGS="${EXTRA_C_FLAGS}" CXXFLAGS="${EXTRA_CXX_FLAGS}" cmake -DBOOST_ROOT_DIR=${HOME}/dependencies/boost_${BOOST_FILE_VERSION} -DLIBUV_ROOT_DIR=${HOME}/dependencies/libuv-${LIBUV_VERSION}/ -DCASS_BUILD_STATIC=ON -DCASS_BUILD_EXAMPLES=ON -DCASS_BUILD_TESTS=ON -DCASS_USE_BOOST_ATOMIC=${USE_BOOST_ATOMIC} .
+  - (
+      mkdir build;
+      cd build;
+      CFLAGS="${EXTRA_C_FLAGS}" CXXFLAGS="${EXTRA_CXX_FLAGS}" cmake -DCMAKE_BUILD_TYPE=Release -DBOOST_ROOT_DIR=${HOME}/dependencies/boost_${BOOST_FILE_VERSION} -DLIBUV_ROOT_DIR=${HOME}/dependencies/libuv-${LIBUV_VERSION}/ -DCASS_BUILD_STATIC=On -DCASS_BUILD_EXAMPLES=On -DCASS_BUILD_TESTS=On ..
+    )
 script:
-  - make -j2
-  - test/unit_tests/cassandra_unit_tests;
+  - make -C build -j${PROCS}
+  - build/test/unit_tests/cassandra_unit_tests
+  - if [ -f build/libcassandra_static.a ]; then
+      declare -a FUNCTIONS MISSING_FUNCTIONS;
+      FUNCTIONS=($(grep -Eoh '^cass_\s*(\w+)\s*\(' include/cassandra.h | awk -F '(' '{print $1}'));
+      for function in "${FUNCTIONS[@]}"; do
+        nm build/libcassandra_static.a | grep ${function} > /dev/null;
+        if [ $? -ne 0 ]; then
+          MISSING_DEFINITION+=("${function}");
+        fi;
+      done;
+      if [ ! -z "${MISSING_DEFINITION}" ]; then
+        printf "Function(s) have no definition:\n";
+        for function in ${MISSING_DEFINITION[@]}; do
+          printf "  ${function}\n";
+        done;
+        exit 1;
+      fi;
+    fi

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1055,22 +1055,6 @@ cass_cluster_set_queue_size_event(CassCluster* cluster,
                                   unsigned queue_size);
 
 /**
- * Sets the size of the fixed size queue that stores
- * log messages.
- *
- * <b>Default:</b> 8192
- *
- * @public @memberof CassCluster
- *
- * @param[in] cluster
- * @param[in] queue_size
- * @return CASS_OK if successful, otherwise an error occurred.
- */
-CASS_EXPORT CassError
-cass_cluster_set_queue_size_log(CassCluster* cluster,
-                                unsigned queue_size);
-
-/**
  * Sets the number of connections made to each server in each
  * IO thread.
  *

--- a/src/error_response.cpp
+++ b/src/error_response.cpp
@@ -38,11 +38,11 @@ CassConsistency cass_error_result_consistency(const CassErrorResult* error_resul
   return error_result->consistency();
 }
 
-cass_int32_t cass_error_result_actual(const CassErrorResult* error_result) {
+cass_int32_t cass_error_result_responses_received(const CassErrorResult* error_result) {
   return error_result->received();
 }
 
-cass_int32_t cass_error_result_required(const CassErrorResult* error_result) {
+cass_int32_t cass_error_result_responses_required(const CassErrorResult* error_result) {
   return error_result->required();
 }
 


### PR DESCRIPTION
* Removed `cass_cluster_set_queue_size_log` from API header
* Corrected API methods
  * `cass_error_result_actual` => `cass_error_result_responses_required`
  * `cass_error_result_required` => `cass_error_result_responses_required`
* TravisCI updates
  * Added a exported symbol check to TravisCI
  * Updating docker instance to use Ubuntu 14.04 (Trusty Tahr)
  * Adding `--no-check-certificate` for downloads (https redirects)
  * Removing Boost atomic usage
  * Moving processor count to environment variable