### PR TITLE
CPP325: Add the ability to set the default consistency level for statements

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1012,6 +1012,36 @@ cass_cluster_set_use_beta_protocol_version(CassCluster* cluster,
                                            cass_bool_t enable);
 
 /**
+ * Sets default consistency level of statement.
+ *
+ * <b>Default:</b> CASS_CONSISTENCY_LOCAL_ONE
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] consistency
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+CASS_EXPORT CassError
+cass_cluster_set_consistency(CassCluster* cluster,
+                             CassConsistency consistency);
+
+/**
+ * Sets default serial consistency level of statement.
+ *
+ * <b>Default:</b> CASS_CONSISTENCY_ANY
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] consistency
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+CASS_EXPORT CassError
+cass_cluster_set_serial_consistency(CassCluster* cluster,
+                                    CassConsistency consistency);
+
+/**
  * Sets the number of IO threads. This is the number of threads
  * that will handle query requests.
  *

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -73,6 +73,24 @@ CassError cass_cluster_set_use_beta_protocol_version(CassCluster* cluster,
   return CASS_OK;
 }
 
+CassError cass_cluster_set_consistency(CassCluster* cluster,
+                                       CassConsistency consistency) {
+  if (consistency == CASS_CONSISTENCY_UNKNOWN) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  cluster->config().set_consistency(consistency);
+  return CASS_OK;
+}
+
+CassError cass_cluster_set_serial_consistency(CassCluster* cluster,
+                                              CassConsistency consistency) {
+  if (consistency == CASS_CONSISTENCY_UNKNOWN) {
+    return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  cluster->config().set_serial_consistency(consistency);
+  return CASS_OK;
+}
+
 CassError cass_cluster_set_num_threads_io(CassCluster* cluster,
                                           unsigned num_threads) {
   if (num_threads == 0) {


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/CPP-325

- add api `cass_request_set_default_consistency`, ` cass_request_get_default_consistency` 
- initial default value is `CASS_CONSISTENCY_LOCAL_ONE` (unchanged)
