### PR TITLE
Fix documentaion of installing openssl on mac

### DIFF
--- a/topics/building/README.md
+++ b/topics/building/README.md
@@ -72,8 +72,9 @@ additional configuration before building the driver.
 
 ```bash
 brew install openssl
-brew link --force openssl
+export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
 ```
+**NOTE:** brew refuses `brew link --force openssl`, so you have to set openssl path manually.
 
 #### Ubuntu
 


### PR DESCRIPTION
brew refuses `brew link --force openssl`(https://github.com/Homebrew/brew/pull/597). 
So we need to set openssl path in another way.  One way is to set `OPENSSL_ROOT_DIR`.