### PR TITLE
CPP-516: Update build documentation

### DIFF
--- a/cmake/modules/FindOpenSSL.cmake
+++ b/cmake/modules/FindOpenSSL.cmake
@@ -66,6 +66,7 @@ if (WIN32)
   unset(_programfiles)
 else ()
   set(_OPENSSL_ROOT_HINTS
+    /usr/local/opt/openssl
     ${OPENSSL_ROOT_DIR}
     ENV OPENSSL_ROOT_DIR
     )

--- a/docs.yaml
+++ b/docs.yaml
@@ -39,6 +39,7 @@ rewrites:
   - http://pkgs.repoforge.org/git/: https://dl.fedoraproject.org/pub/epel/
   - http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el5.rf.i386.rpm: http://dl.fedoraproject.org/pub/epel/5/i386/epel-release-5-4.noarch.rpm
   - http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.3-1.el5.rf.x86_64.rpm: http://dl.fedoraproject.org/pub/epel/5/x86_64/epel-release-5-4.noarch.rpm
+  - ../../vc_build.bat: https://github.com/datastax/cpp-driver/blob/master/vc_build.bat
 versions:
   - name: 2.7
     ref: 2.7.0

--- a/topics/building/README.md
+++ b/topics/building/README.md
@@ -1,199 +1,242 @@
 # Building
 
-## Supported Platforms
-The driver is known to work on CentOS/RHEL 5/6/7, Mac OS X 10.8/10.9/10.10/10.11
-(Moutain Lion, Mavericks, Yosemite, and El Capitan), Ubuntu 12.04/14.04 LTS, and
-Windows 7 SP1 and above.
+The C/C++ driver will build on most standard Unix-like and Microsoft Windows
+platforms. Packages are available for the following platforms:
 
-It has been built using GCC 4.1.2+, Clang 3.4+, and MSVC 2010/2012/2013/2015.
+* [CentOS 6][cpp-driver-centos6]
+* [CentOS 7][cpp-driver-centos7]
+* [Ubuntu 14.04 LTS][cpp-driver-ubuntu14-04]
+* [Ubuntu 16.04 LTS][cpp-driver-ubuntu16-04]
+* [Windows][cpp-driver-windows]
+
+__NOTE__: The build procedures only need to be performed for driver development
+          or if your system doesn't have packages available for download and
+          installation.
+
+## Compatibility
+
+* Architectures: 32-bit (x86) and 64-bit (x64)
+* Compilers: GCC 4.1.2+ Clang 3.4+, and MSVC 2010/2012/2013/2015/2017
 
 ## Dependencies
 
-### Driver
+The C/C++ driver depends on the following software:
 
-- [CMake](http://www.cmake.org)
-- [libuv (1.x or 0.10.x)](https://github.com/libuv/libuv)
-- [OpenSSL](http://www.openssl.org/) (optional)
+* [CMake] v2.6.4+
+* [libuv] 1.x
+* [OpenSSL] v1.0.x
 
-**NOTE:** Utilizing the default package manager configuration to install
-dependencies on \*nix based operating systems may result in older versions of
-dependencies being installed.
+## Linux/Mac OS
 
-### Test Dependencies
+The driver is known to build on CentOS/RHEL 6/7, Mac OS X 10.10/10.11 (Yosemite
+and El Capitan), Mac OS 10.12 (Sierra), and Ubuntu 14.04/16.04 LTS.
 
-- [boost 1.59+](http://www.boost.org)
-- [libssh2](http://www.libssh2.org) (optional)
+__NOTE__: The driver will also build on most standard Unix-like systems using
+          GCC 4.1.2+ or Clang 3.4+.
 
-## Linux/OS X
-The driver has been built using both Clang (Ubuntu 12.04/14.04 and OS X) and GCC
-(Linux).
+### Installing dependencies
 
-### Obtaining Dependencies
+#### Initial environment setup
 
-#### CentOS/RHEL
-
-##### Additional Requirements for CentOS/RHEL 5
-CentOS/RHEL 5 does not contain `git` in its core repositories; however, the [EPEL] has
-this dependency.
+##### CentOS/RHEL (Yum)
 
 ```bash
-sudo yum -y install epel-release
+yum install automake cmake gcc-c++ git libtool
 ```
 
-##### Dependencies and libuv Installation
+##### Ubuntu (APT)
 
 ```bash
-sudo yum install automake cmake gcc-c++ git libtool openssl-devel wget
+apt-get update
+apt-get install build-essential cmake git
+```
+
+##### Mac OS (Brew)
+
+[Homebrew][Homebrew] (or brew) is a free and open-source software package
+management system that simplifies the installation of software on the Mac OS
+operating system. Ensure [Homebrew is installed][Homebrew] before proceeding.
+
+```bash
+brew update
+brew upgrade
+brew install autoconf automake cmake libtool
+```
+
+#### libuv
+
+libuv v1.x should be used in order to ensure all features of the C/C++ driver
+are available. When using a package manager for your operating system make sure
+you install v1.x; if available.
+
+##### CentOS/RHEL and Ubuntu packages
+
+Packages are available from our [download server]:
+
+* [CentOS 6][libuv-centos6]
+* [CentOS 7][libuv-centos7]
+* [Ubuntu 14.04 LTS][libuv-ubuntu14-04]
+* [Ubuntu 16.04 LTS][libuv-ubuntu16-04]
+
+##### Mac OS (Brew)
+
+```bash
+brew install libuv
+```
+
+##### Manually build and install
+
+_The following procedures should be performed if packages are not available for
+your system._
+
+```bash
 pushd /tmp
-wget http://dist.libuv.org/dist/v1.11.0/libuv-v1.11.0.tar.gz
-tar xzf libuv-v1.11.0.tar.gz
-pushd libuv-v1.11.0
+wget http://dist.libuv.org/dist/v1.14.0/libuv-v1.14.0.tar.gz
+tar xzf libuv-v1.14.0.tar.gz
+pushd libuv-v1.14.0
 sh autogen.sh
 ./configure
-sudo make install
+make install
 popd
 popd
 ```
 
-#### OS X
-The driver has been built and tested using the Clang compiler provided by XCode
-5.1+. The dependencies were obtained using [Homebrew](http://brew.sh).
+#### OpenSSL
+
+##### CentOS (Yum)
 
 ```bash
-brew install libuv cmake
+yum install openssl-devel
 ```
 
-**NOTE:** The driver utilizes the OpenSSL library included with XCode unless
-          running XCode 7+.
+##### Ubuntu (APT)
 
-##### Additional Requirements for 10.11+ (El Capitan) and XCode 7+
-OpenSSL has been officially removed from the OS X SDK 10.11+ and requires
-additional configuration before building the driver.
+```bash
+apt-get install libssl-dev
+```
+
+##### Mac OS (Brew)
 
 ```bash
 brew install openssl
+```
+
+__Note__: For Mac OS X 10.11 (El Capitan) and Mac OS 10.12 (Sierra) a link
+          needs to be created in order to make OpenSSL available to the
+          building libraries:
+
+```bash
 brew link --force openssl
 ```
 
-#### Ubuntu
-
-##### Additional Requirements for Ubuntu 12.04
-Ubuntu 12.04 does not contain libuv in its repositories; however the LinuxJedi
-PPA has a backport from Ubuntu 14.04 which can be found
-[here](https://launchpad.net/~linuxjedi/+archive/ubuntu/ppa).
+### Building and installing the C/C++ driver
 
 ```bash
-sudo apt-add-repository ppa:linuxjedi/ppa
-sudo apt-get update
-```
-
-##### GCC
-
-```bash
-sudo apt-get install g++ make cmake libuv-dev libssl-dev
-```
-
-##### Clang
-
-```bash
-sudo apt-get install clang make cmake libuv-dev libssl-dev
-```
-
-### Building the Driver
-
-```bash
-git clone https://github.com/datastax/cpp-driver.git
-mkdir cpp-driver/build
-cd cpp-driver/build
+mkdir build
+pushd build
 cmake ..
 make
+make install
+popd
 ```
 
-### Test Dependencies and Building the Tests (_NOT REQUIRED_)
+#### Building examples (optional)
 
-#### Obtaining Test Dependencies
-
-##### CentOS/RHEL
-CentOS/RHEL does not contain Boost v1.59+ libraries in its repositories; however
-these can be easily installed from source. Ensure previous version of Boost has
-been removed by executing the command `sudo yum remove boost*` before
-proceeding.
+Examples are not built by default and need to be enabled. Update your [CMake]
+line to build examples.
 
 ```bash
-sudo yum install libssh2-devel
+cmake -DCASS_BUILD_EXAMPLES=On ..
+```
+
+#### Building tests (optional)
+
+Tests (integration and unit) are not built by default and need to be enabled.
+Before proceeding [Boost] v1.59.0+ must be installed to properly configure and
+build the integration and unit tests.
+
+Once [Boost] is installed, update your CMake line to build tests.
+
+##### Boost
+
+###### CentOS/RHEL and Ubuntu
+
+CentOS/RHEL and Ubuntu do not contain Boost v1.59+ libraries in its
+repositories; however the following steps will install Boost from source:
+
+__Note__: Ensure previous version of Boost has been removed before proceeding.
+
+```bash
 pushd /tmp
-wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz/download -O boost_1_63_0.tar.gz
-tar xzf boost_1_63_0.tar.gz
-pushd boost_1_63_0
+wget http://sourceforge.net/projects/boost/files/boost/1.64.0/boost_1_64_0.tar.gz/download -O boost_1_64_0.tar.gz
+tar xzf boost_1_64_0.tar.gz
+pushd boost_1_64_0
 ./bootstrap.sh --with-libraries=atomic,chrono,system,thread,test
 sudo ./b2 cxxflags="-fPIC" install
 popd
 popd
 ```
 
-**NOTE:** CentOS/RHEL 5 has known issues when compiling tests with GCC 4.1.2 as
-it is not a supported Boost compiler.
-
-##### OS X
+###### Mac OS
 
 ```bash
-brew install boost libssh2
+brew install boost
 ```
 
-##### Ubuntu
-Ubuntu does not contain Boost v1.59+ libraries in its repositories; however
-these can be easily installed from source.
+##### Integration tests
 
 ```bash
-sudo apt-get install libssh2-1-dev
-pushd /tmp
-wget http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz/download -O boost_1_63_0.tar.gz
-tar xzf boost_1_63_0.tar.gz
-pushd boost_1_63_0
-./bootstrap.sh --with-libraries=atomic,chrono,system,thread,test
-sudo ./b2 install
-popd
-popd
+cmake -DCASS_BUILD_INTEGRATION_TESTS=On ..
 ```
 
-#### Building the Driver with the Tests
+##### Unit tests
 
 ```bash
-git clone https://github.com/datastax/cpp-driver.git
-mkdir cpp-driver/build
-cd cpp-driver/build
-cmake -DCASS_BUILD_TESTS=ON ..
-make
+cmake -DCASS_BUILD_UNIT_TESTS=On ..
 ```
+
 
 ## Windows
-The driver has been built and tested using Microsoft Visual Studio 2010, 2012,
-2013 and 2015 (using the "Express" and Professional versions) and Windows SDK
-v7.1, 8.0, 8.1, and 10.0 on Windows 7 SP1 and above. The library dependencies
-will automatically download and build; however the following build dependencies
-will need to be installed.
 
-### Obtaining Build Dependencies
-- Download and install [CMake](http://www.cmake.org/download).
- - Make sure to select the option "Add CMake to the system PATH for all users"
-   or "Add CMake to the system PATH for current user".
-- Download and install [Git](http://git-scm.com/download/win)
- - Make sure to select the option "Use Git from Windows Command Prompt" or
-   manually add the git executable to the system PATH.
-- Download and install [ActiveState Perl](https://www.perl.org/get.html#win32)
- - Make sure to select the option "Add Perl to PATH environment variable".
- - **NOTE:** This build dependency is required if building with OpenSSL support
-- Download and install [Python v2.7.x](https://www.python.org/downloads)
- - Make sure to select/install the feature "Add python.exe to Path"
+We provide a self-contained [batch script] for building the C/C++ driver and
+all of its dependencies. In order to run it, you have to install the build
+dependencies and clone the repository with the DataStax C/C++ driver for
+DataStax Enterprise.
 
-### Building the Driver
-A batch script has been created to detect installed versions of Visual Studio
-(and/or Windows SDK installations) to simplify the build process on Windows. If
-you have more than one version of Visual Studio (and/or Windows SDK) installed
-you will be prompted to select which version to use when compiling the driver.
+### Obtaining build dependencies
 
-First you will need to open a "Command Prompt" (or Windows SDK Command Prompt)
-to execute the batch script.
+* Download and install [Bison]
+  * Make sure Bison is in your system PATH and not installed in a directory with
+    spaces (e.g. `%SYSTEMDRIVE%\GnuWin32`)
+* Download and install [CMake]
+  * Make sure to select the option "Add CMake to the system PATH for all users"
+    or "Add CMake to the system PATH for current user"
+* Download and install [Git]
+  * Make sure to select the option "Use Git from Windows Command Prompt" or
+    manually add the git executable to the system PATH.
+* Download and install [ActiveState Perl]
+  * Make sure to select the option "Add Perl to PATH environment variable"
+* Download and install [Python v2.7.x][python-27]
+  * Make sure to select/install the feature "Add python.exe to Path"
+* Download and install [Boost][Boost] (Optional: Tests only)
+  * Visual Studio 2010: [32-bit][boost-msvc-100-32-bit]/[64-bit][boost-msvc-100-64-bit]
+  * Visual Studio 2012: [32-bit][boost-msvc-110-32-bit]/[64-bit][boost-msvc-110-64-bit]
+  * Visual Studio 2013: [32-bit][boost-msvc-120-32-bit]/[64-bit][boost-msvc-120-64-bit]
+  * Visual Studio 2015: [32-bit][boost-msvc-140-32-bit]/[64-bit][boost-msvc-140-64-bit]
+  * Visual Studio 2015: [32-bit][boost-msvc-141-32-bit]/[64-bit][boost-msvc-141-64-bit]
+
+### Building the driver
+
+The [batch script] detects installed versions of Visual Studio to simplify the
+build process on Windows and select the correct version of Visual Studio when
+compiling the driver.
+
+First you will need to open a "Command Prompt" to execute the batch script.
+Running the batch script without any arguments will build the driver for C/C++
+driver for the current system architecture (e.g. x64).
+
+To perform advanced build configuration, execute the batch script with the
+`--HELP` argument to display the options available.
 
 ```dos
 Usage: VC_BUILD.BAT [OPTION...]
@@ -202,7 +245,7 @@ Usage: VC_BUILD.BAT [OPTION...]
     --RELEASE                         Enable release build (default)
     --DISABLE-CLEAN                   Disable clean build
     --DEPENDENCIES-ONLY               Build dependencies only
-    --TARGET-COMPILER [version]       140, 120, 110, 100, or WINSDK
+    --TARGET-COMPILER [version]       141, 140, 120, 110, or 100
     --DISABLE-OPENSSL                 Disable OpenSSL support
     --ENABLE-EXAMPLES                 Enable example builds
     --ENABLE-PACKAGES [version]       Enable package generation (*)
@@ -211,6 +254,7 @@ Usage: VC_BUILD.BAT [OPTION...]
     --INSTALL-DIR [install-dir]       Override installation directory
     --SHARED                          Build shared library (default)
     --STATIC                          Build static library
+    --ENABLE-SHARED-OPENSSL           Force shared OpenSSL library
     --X86                             Target 32-bit build (***)
     --X64                             Target 64-bit build (***)
     --USE-BOOST-ATOMIC                Use Boost atomic
@@ -218,7 +262,7 @@ Usage: VC_BUILD.BAT [OPTION...]
     Testing Arguments
 
     --ENABLE-TESTS
-         [boost-root-dir]             Enable test builds
+         [boost-root-dir]             Enable integration and unit tests build
     --ENABLE-INTEGRATION-TESTS
          [boost-root-dir]             Enable integration tests build
     --ENABLE-UNIT-TESTS
@@ -232,91 +276,37 @@ Usage: VC_BUILD.BAT [OPTION...]
 *** Default target architecture is determined based on system architecture
 ```
 
-To build 32-bit shared library:
+__Note__: When overriding installation directory using `--INSTALL-DIR`, the
+          driver dependencies will also be copied (e.g.
+          C:\myproject\dependencies\libs)
 
-```dos
-VC_BUILD.BAT --X86
-```
-
-To build 64-bit shared library:
-
-```dos
-VC_BUILD.BAT --X64
-```
-
-To build using Boost atomic implementation:
-
-```dos
-VC_BUILD.BAT --USE-BOOST-ATOMIC
-```
-
-To build static library:
-
-```dos
-VC_BUILD.BAT --STATIC
-```
-
-To build examples:
-
-```dos
-VC_BUILD.BAT --ENABLE-EXAMPLES
-```
-
-To build library without OpenSSL support:
-
-```dos
-VC_BUILD.BAT --DISABLE-OPENSSL
-```
-
-To build 32-bit static library without OpenSSL support:
-
-```dos
-VC_BUILD.BAT --DISABLE-OPENSSL --STATIC --X86
-```
-
-To generate Visual Studio solution file:
-
-```dos
-VC_BUILD.BAT --GENERATE-SOLUTION
-```
-
-To use vc_build.bat for easy inclusion into a project:
-
-```dos
-VC_BUILD.BAT --TARGET-COMPILER 120 --INSTALL-DIR C:\myproject\dependencies\libs\cpp-driver
-```
-
-**NOTE:** When overriding installation directory using `--INSTALL-DIR`, the
-driver dependencies will also be copied (e.g. C:\myproject\dependencies\libs)
-
-### Test Dependencies and Building the Tests (_NOT REQUIRED_)
-
-#### Obtaining Test Dependencies
-Boost v1.59+ is the only external dependency that will need to be obtained in
-order to build the unit and integration tests.
-
-To simplify the process; pre-built binaries can be obtained
-[here](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/).
-Ensure the proper Visual Studio (or Windows SDK) version and architecture is
-obtained and select from the following list:
-
-- Visual Studio 2010 (Windows SDK 7.1)
- - Boost v1.63.0 [32-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-10.0-32.exe/download)/[64-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-10.0-64.exe/download)
-- Visual Studio 2012 (Windows SDK 8.0)
- - Boost v1.63.0 [32-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-11.0-32.exe/download)/[64-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-11.0-64.exe/download)
-- Visual Studio 2013 (Windows SDK 8.1)
- - Boost v1.63.0 [32-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-12.0-32.exe/download)/[64-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-12.0-64.exe/download)
-- Visual Studio 2015 (Windows SDK 10.0)
- - Boost v1.63.0 [32-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-14.0-32.exe/download)/[64-bit](http://sourceforge.net/projects/boost/files/boost-binaries/1.63.0/boost_1_63_0-msvc-14.0-64.exe/download)
-
-#### Building the Driver with the Tests
-
-```dos
-VC_BUILD.BAT --STATIC --ENABLE-TESTS <ABSOLUTE-PATH-TO-BOOST>
-
-[e.g. C:\local\boost_1_63_0]
-```
- **NOTE:** When enabling tests, --USE-BOOST-ATOMIC will use the Boost atomic
- implementation supplied by <ABSOLUTE-PATH-TO-BOOST>
-
-[EPEL]: https://fedoraproject.org/wiki/EPEL
+[download server]: http://downloads.datastax.com
+[cpp-driver-centos6]: http://downloads.datastax.com/cpp-driver/centos/6/cassandra
+[cpp-driver-centos7]: http://downloads.datastax.com/cpp-driver/centos/7/cassandra
+[cpp-driver-ubuntu14-04]: http://downloads.datastax.com/cpp-driver/ubuntu/14.04/cassandra
+[cpp-driver-ubuntu16-04]: http://downloads.datastax.com/cpp-driver/ubuntu/16.04/cassandra
+[cpp-driver-windows]: http://downloads.datastax.com/cpp-driver/windows/cassandra
+[libuv-centos6]: http://downloads.datastax.com/cpp-driver/centos/6/dependencies/libuv
+[libuv-centos7]: http://downloads.datastax.com/cpp-driver/centos/7/dependencies/libuv
+[libuv-ubuntu14-04]: http://downloads.datastax.com/cpp-driver/ubuntu/14.04/dependencies/libuv
+[libuv-ubuntu16-04]: http://downloads.datastax.com/cpp-driver/ubuntu/16.04/dependencies/libuv
+[batch script]: ../../vc_build.bat
+[Homebrew]: https://brew.sh
+[Bison]: http://gnuwin32.sourceforge.net/downlinks/bison.php
+[CMake]: http://www.cmake.org/download
+[Git]: http://git-scm.com/download/win
+[ActiveState Perl]: https://www.perl.org/get.html#win32
+[python-27]: https://www.python.org/downloads
+[libuv]: http://libuv.org
+[OpenSSL]: https://www.openssl.org
+[Boost]: http://www.boost.org
+[boost-msvc-100-32-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-10.0-32.exe/download
+[boost-msvc-100-64-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-10.0-64.exe/download
+[boost-msvc-110-32-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-11.0-32.exe/download
+[boost-msvc-110-64-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-11.0-64.exe/download
+[boost-msvc-120-32-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-12.0-32.exe/download
+[boost-msvc-120-64-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-12.0-64.exe/download
+[boost-msvc-140-32-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-14.0-32.exe/download
+[boost-msvc-140-64-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-14.0-64.exe/download
+[boost-msvc-141-32-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-14.1-32.exe/download
+[boost-msvc-141-64-bit]: http://sourceforge.net/projects/boost/files/boost-binaries/1.64.0/boost_1_64_0-msvc-14.1-64.exe/download

--- a/topics/building/README.md
+++ b/topics/building/README.md
@@ -103,6 +103,10 @@ popd
 
 #### OpenSSL
 
+The DataStax C/C++ driver requires OpenSSL v1.0.x; v1.1.x+ is not currently
+supported by the driver. Ensure that you are installing and using a compatible
+version of OpenSSL.
+
 ##### CentOS (Yum)
 
 ```bash
@@ -127,6 +131,20 @@ __Note__: For Mac OS X 10.11 (El Capitan) and Mac OS 10.12 (Sierra) a link
 
 ```bash
 brew link --force openssl
+```
+
+##### Manually build and install
+
+```bash
+pushd /tmp
+wget --no-check-certificate https://www.openssl.org/source/openssl-1.0.2l.tar.gz
+tar xzf openssl-1.0.2l.tar.gz
+pushd openssl-1.0.2l
+CFLAGS=-fpic ./config shared
+make
+make install
+popd
+popd
 ```
 
 ### Building and installing the C/C++ driver


### PR DESCRIPTION
Cherry picked [449c457](https://github.com/riptano/cpp-dse-driver/commit/449c457948ab720c2d4b9f31a7532604f17ecc93) to correct build issues on Mac OS and keep the documentation generic.