### PR TITLE
CPP-486: Handle compiler warning `implicit-fallthrough` on C++17 compilers

### DIFF
--- a/src/murmur3.cpp
+++ b/src/murmur3.cpp
@@ -115,24 +115,24 @@ int64_t MurmurHash3_x64_128(const void * key, const int len,
   // tail
   switch (len & 15)
   {
-    case 15: k2 ^= ((int64_t) (tail[14])) << 48;
-    case 14: k2 ^= ((int64_t) (tail[13])) << 40;
-    case 13: k2 ^= ((int64_t) (tail[12])) << 32;
-    case 12: k2 ^= ((int64_t) (tail[11])) << 24;
-    case 11: k2 ^= ((int64_t) (tail[10])) << 16;
-    case 10: k2 ^= ((int64_t) (tail[ 9])) << 8;
+    case 15: k2 ^= ((int64_t) (tail[14])) << 48; /* FALLTHRU */
+    case 14: k2 ^= ((int64_t) (tail[13])) << 40; /* FALLTHRU */
+    case 13: k2 ^= ((int64_t) (tail[12])) << 32; /* FALLTHRU */
+    case 12: k2 ^= ((int64_t) (tail[11])) << 24; /* FALLTHRU */
+    case 11: k2 ^= ((int64_t) (tail[10])) << 16; /* FALLTHRU */
+    case 10: k2 ^= ((int64_t) (tail[ 9])) << 8;  /* FALLTHRU */
     case  9: k2 ^= ((int64_t) (tail[ 8])) << 0;
-             k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2;
+             k2 *= c2; k2  = ROTL64(k2,33); k2 *= c1; h2 ^= k2; /* FALLTHRU */
 
-    case  8: k1 ^= ((int64_t) (tail[ 7])) << 56;
-    case  7: k1 ^= ((int64_t) (tail[ 6])) << 48;
-    case  6: k1 ^= ((int64_t) (tail[ 5])) << 40;
-    case  5: k1 ^= ((int64_t) (tail[ 4])) << 32;
-    case  4: k1 ^= ((int64_t) (tail[ 3])) << 24;
-    case  3: k1 ^= ((int64_t) (tail[ 2])) << 16;
-    case  2: k1 ^= ((int64_t) (tail[ 1])) << 8;
+    case  8: k1 ^= ((int64_t) (tail[ 7])) << 56; /* FALLTHRU */
+    case  7: k1 ^= ((int64_t) (tail[ 6])) << 48; /* FALLTHRU */
+    case  6: k1 ^= ((int64_t) (tail[ 5])) << 40; /* FALLTHRU */
+    case  5: k1 ^= ((int64_t) (tail[ 4])) << 32; /* FALLTHRU */
+    case  4: k1 ^= ((int64_t) (tail[ 3])) << 24; /* FALLTHRU */
+    case  3: k1 ^= ((int64_t) (tail[ 2])) << 16; /* FALLTHRU */
+    case  2: k1 ^= ((int64_t) (tail[ 1])) << 8;  /* FALLTHRU */
     case  1: k1 ^= ((int64_t) (tail[ 0])) << 0;
-             k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1;
+             k1 *= c1; k1  = ROTL64(k1,31); k1 *= c2; h1 ^= k1; /* FALLTHRU */
   };
 
   //----------

--- a/src/third_party/rapidjson/patches/remove_implicit-fallthrough_warnings.diff
+++ b/src/third_party/rapidjson/patches/remove_implicit-fallthrough_warnings.diff
@@ -1,0 +1,23 @@
+diff -rup /tmp/rapidjson/include/rapidjson/reader.h
+--- /tmp/rapidjson/include/rapidjson/reader.h	2017-08-25 16:42:26.786046697 +0000
++++ rapidjson/reader.h	2017-08-25 16:45:04.950919345 +0000
+@@ -495,8 +495,7 @@ private:
+                 case '}': 
+                     if (!handler.EndObject(memberCount))
+                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+-                    else
+-                        return;
++                    return;
+                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell());
+             }
+         }
+@@ -532,8 +531,7 @@ private:
+                 case ']': 
+                     if (!handler.EndArray(elementCount))
+                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+-                    else
+-                        return;
++                    return;
+                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorArrayMissCommaOrSquareBracket, is.Tell());
+             }
+         }

--- a/src/third_party/rapidjson/rapidjson/reader.h
+++ b/src/third_party/rapidjson/rapidjson/reader.h
@@ -495,8 +495,7 @@ private:
                 case '}': 
                     if (!handler.EndObject(memberCount))
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
-                    else
-                        return;
+                    return;
                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell());
             }
         }
@@ -532,8 +531,7 @@ private:
                 case ']': 
                     if (!handler.EndArray(elementCount))
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
-                    else
-                        return;
+                    return;
                 default:  RAPIDJSON_PARSE_ERROR(kParseErrorArrayMissCommaOrSquareBracket, is.Tell());
             }
         }


### PR DESCRIPTION
Tested with GCC v7.1.1-3 on Fedora 26