### PR TITLE
CPP-513 - Copy-on-write keyspace logic is incorrect

### DIFF
--- a/src/io_worker.hpp
+++ b/src/io_worker.hpp
@@ -93,8 +93,9 @@ public:
     protocol_version_.store(protocol_version);
   }
 
-  const CopyOnWritePtr<std::string> keyspace() const { return keyspace_; }
+  std::string keyspace() const;
   void set_keyspace(const std::string& keyspace);
+
   void broadcast_keyspace_change(const std::string& keyspace);
 
   void set_host_is_available(const Address& address, bool is_available);
@@ -148,7 +149,8 @@ private:
   Atomic<int> protocol_version_;
   uv_prepare_t prepare_;
 
-  CopyOnWritePtr<std::string> keyspace_;
+  std::string keyspace_;
+  mutable uv_mutex_t keyspace_mutex_;
 
   AddressSet unavailable_addresses_;
   uv_mutex_t unavailable_addresses_mutex_;

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -243,17 +243,18 @@ void Pool::set_is_available(bool is_available) {
 
 bool Pool::write(Connection* connection, const SpeculativeExecution::Ptr& speculative_execution) {
   speculative_execution->set_pool(this);
-  if (*io_worker_->keyspace() == connection->keyspace()) {
+  std::string keyspace(io_worker_->keyspace());
+  if (keyspace == connection->keyspace()) {
     if (!connection->write(speculative_execution, false)) {
       return false;
     }
   } else {
     LOG_DEBUG("Setting keyspace %s on connection(%p) pool(%p)",
-              io_worker_->keyspace()->c_str(),
+              keyspace.c_str(),
               static_cast<void*>(connection),
               static_cast<void*>(this));
     if (!connection->write(RequestCallback::Ptr(
-                             new SetKeyspaceCallback(*io_worker_->keyspace(),
+                             new SetKeyspaceCallback(keyspace,
                                                      speculative_execution)),
                            false)) {
       return false;
@@ -303,7 +304,7 @@ void Pool::spawn_connection() {
     Connection* connection =
         new Connection(loop_, config_, metrics_,
                        host_,
-                       *io_worker_->keyspace(),
+                       io_worker_->keyspace(),
                        io_worker_->protocol_version(),
                        this);
 

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -87,6 +87,11 @@ public:
     load_balancing_policy_.reset(policy);
   }
 
+private:
+  std::string keyspace() const;
+  void set_keyspace(const std::string& keyspace);
+
+public:
   void broadcast_keyspace_change(const std::string& keyspace,
                                  const IOWorker* calling_io_worker);
 
@@ -215,7 +220,8 @@ private:
   int pending_workers_count_;
   int current_io_worker_;
 
-  CopyOnWritePtr<std::string> keyspace_;
+  std::string keyspace_;
+  mutable uv_mutex_t keyspace_mutex_;
 };
 
 class SessionFuture : public Future {


### PR DESCRIPTION
The keyspace state in session is attempting to use CopyOnWritePtr as a
mechanism to prevent locking however it just ends up using it as a share
pointer swap which is not atomic. This is a data race and could cause a
memory leak (or freed memory access).