### PR TITLE
CPP-535: Schema metadata views not being properly updated

### DIFF
--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1108,18 +1108,27 @@ void KeyspaceMetadata::add_table(const TableMetadata::Ptr& table) {
   // If there's a previous version of this table then copy its views
   // to the new version of the table, and update the table back-refs
   // in the views.
-
   if (table_it != tables_->end()) {
     TableMetadata::Ptr old_table(table_it->second);
-    for (ViewMetadata::Vec::const_iterator i = old_table->views().begin(),
-           end = old_table->views().end(); i != end; ++i) {
-      ViewMetadata::Ptr view(new ViewMetadata(**i, table.get()));
-      table->add_view(view);
-      (*views_)[view->name()] = view;
-    }
+    internal_add_table(table, old_table->views());
+  } else {
+    (*tables_)[table->name()] = table; // Add new table
+  }
+}
+
+void KeyspaceMetadata::internal_add_table(const TableMetadata::Ptr& table,
+                                          const ViewMetadata::Vec& views) {
+  // Copy all the views and update the table and keyspace views
+  for (ViewMetadata::Vec::const_iterator i = views.begin();
+        i != views.end(); ++i) {
+    ViewMetadata::Ptr view(new ViewMetadata(**i, table.get()));
+    table->add_view(view);
+    (*views_)[view->name()] = view;
   }
   (*tables_)[table->name()] = table;
 }
+
+
 
 const ViewMetadata* KeyspaceMetadata::get_view(const std::string& name) const {
   ViewMetadata::Map::const_iterator i = views_->find(name);
@@ -1164,18 +1173,11 @@ void KeyspaceMetadata::drop_table_or_view(const std::string& table_or_view_name)
         views.erase(i);
       }
 
-      // Create new instance of the base table
+      // Create and add a new copy of the base table
       TableMetadata::Ptr table(new TableMetadata(*view->base_table()));
+      internal_add_table(table, views);
 
-      // Copy all the views and update the table and keyspace views
-      for (ViewMetadata::Vec::const_iterator i = views.begin();
-           i != views.end(); ++i) {
-        ViewMetadata::Ptr view(new ViewMetadata(**i, table.get()));
-        table->add_view(view);
-        (*views_)[view->name()] = view;
-      }
-      (*tables_)[table->name()] = table;
-
+      // Remove the dropped view
       views_->erase(view_it);
     }
   }

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1164,7 +1164,7 @@ void KeyspaceMetadata::drop_table_or_view(const std::string& table_or_view_name)
         views.erase(i);
       }
 
-      // Create new instance of the base table with the view removed
+      // Create new instance of the base table
       TableMetadata::Ptr table(new TableMetadata(*view->base_table()));
 
       // Copy all the views and update the table and keyspace views

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1463,6 +1463,19 @@ TableMetadata::TableMetadata(int protocol_version, const VersionNumber& cassandr
   }
 }
 
+TableMetadata::TableMetadata(const TableMetadata& other,
+                             const ViewMetadata::Vec& views)
+  : TableMetadataBase(other)
+  , views_(views)
+  , indexes_(other.indexes_)
+  , indexes_by_name_(other.indexes_by_name_) {
+  // Update base table on each view
+  for (ViewMetadata::Vec::const_iterator i = views.begin(),
+       end = views.end(); i != end; ++i) {
+    (*i)->base_table(this);
+  }
+}
+
 const ViewMetadata* TableMetadata::get_view(const std::string& name) const {
  ViewMetadata::Vec::const_iterator i = std::lower_bound(views_.begin(), views_.end(), name);
   if (i == views_.end() || (*i)->name() != name) return NULL;
@@ -1504,7 +1517,7 @@ void TableMetadata::key_aliases(SimpleDataTypeCache& cache, KeyAliases* output) 
 const ViewMetadata::Ptr ViewMetadata::NIL;
 
 ViewMetadata::ViewMetadata(int protocol_version, const VersionNumber& cassandra_version,
-                           const TableMetadata* table,
+                           TableMetadata* table,
                            const std::string& name, const RefBuffer::Ptr& buffer, const Row* row)
   : TableMetadataBase(protocol_version, cassandra_version, name, buffer, row)
   , base_table_(table) {

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -582,6 +582,10 @@ public:
   const Value* strategy_options() const { return &strategy_options_; }
 
 private:
+  void internal_add_table(const TableMetadata::Ptr& table,
+                          const ViewMetadata::Vec& views);
+
+private:
   StringRef strategy_class_;
   Value strategy_options_;
 

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -394,23 +394,25 @@ public:
   static const ViewMetadata::Ptr NIL;
 
   ViewMetadata(int protocol_version, const VersionNumber& cassandra_version,
-               const TableMetadata* table,
+               TableMetadata* table,
                const std::string& name,
                const RefBuffer::Ptr& buffer, const Row* row);
 
   ViewMetadata(const ViewMetadata& other,
-               const TableMetadata* table)
+               TableMetadata* table)
     : TableMetadataBase(other)
     , base_table_(table) { }
 
+  void base_table(TableMetadata* base_table) { base_table_ = base_table; }
   const TableMetadata* base_table() const { return base_table_; }
+  TableMetadata* base_table() { return base_table_; }
 
 private:
   // This cannot be a reference counted pointer because it would cause a cycle.
   // This is okay because the lifetime of the table will exceed the lifetime
   // of a table's view. That is, a table's views will be removed when a table is
   // removed.
-  const TableMetadata* base_table_;
+  TableMetadata* base_table_;
 };
 
 class ViewIteratorBase : public Iterator {
@@ -478,12 +480,7 @@ public:
   TableMetadata(int protocol_version, const VersionNumber& cassandra_version, const std::string& name,
                 const RefBuffer::Ptr& buffer, const Row* row);
 
-  TableMetadata(const TableMetadata& other,
-                const ViewMetadata::Vec& views)
-    : TableMetadataBase(other)
-    , views_(views)
-    , indexes_(other.indexes_)
-    , indexes_by_name_(other.indexes_by_name_) { }
+  TableMetadata(const TableMetadata& other, const ViewMetadata::Vec& views);
 
   const ViewMetadata::Vec& views() const { return views_; }
   const IndexMetadata::Vec& indexes() const { return indexes_; }

--- a/src/metadata.hpp
+++ b/src/metadata.hpp
@@ -394,25 +394,23 @@ public:
   static const ViewMetadata::Ptr NIL;
 
   ViewMetadata(int protocol_version, const VersionNumber& cassandra_version,
-               TableMetadata* table,
+               const TableMetadata* table,
                const std::string& name,
                const RefBuffer::Ptr& buffer, const Row* row);
 
   ViewMetadata(const ViewMetadata& other,
-               TableMetadata* table)
+               const TableMetadata* table)
     : TableMetadataBase(other)
     , base_table_(table) { }
 
-  void base_table(TableMetadata* base_table) { base_table_ = base_table; }
   const TableMetadata* base_table() const { return base_table_; }
-  TableMetadata* base_table() { return base_table_; }
 
 private:
   // This cannot be a reference counted pointer because it would cause a cycle.
   // This is okay because the lifetime of the table will exceed the lifetime
   // of a table's view. That is, a table's views will be removed when a table is
   // removed.
-  TableMetadata* base_table_;
+  const TableMetadata* base_table_;
 };
 
 class ViewIteratorBase : public Iterator {
@@ -480,7 +478,10 @@ public:
   TableMetadata(int protocol_version, const VersionNumber& cassandra_version, const std::string& name,
                 const RefBuffer::Ptr& buffer, const Row* row);
 
-  TableMetadata(const TableMetadata& other, const ViewMetadata::Vec& views);
+  TableMetadata(const TableMetadata& other)
+    : TableMetadataBase(other)
+    , indexes_(other.indexes_)
+    , indexes_by_name_(other.indexes_by_name_) { }
 
   const ViewMetadata::Vec& views() const { return views_; }
   const IndexMetadata::Vec& indexes() const { return indexes_; }

--- a/test/integration_tests/src/test_schema_metadata.cpp
+++ b/test/integration_tests/src/test_schema_metadata.cpp
@@ -1592,7 +1592,7 @@ BOOST_AUTO_TEST_CASE(indexes) {
  * Verifies that materialized view metadata is correctly updated and returned.
  *
  * @since 2.3.0
- * @jira_ticket CPP-331
+ * @jira_ticket CPP-331, CPP-501, CPP-503, CPP-535
  * @test_category schema
  * @cassandra_version 3.0.x
  */


### PR DESCRIPTION
* During a drop view event where multiple views exist for a table,
  the view(s) remaining in the TableMetadata were not properly
  updated with the new base table; ViewMetadata::base_table_.

**NOTE**: This PR is set to merge with CPP-534