### PR TITLE
CPP-578 - Add support for `NO_COMPACT` startup option

### DIFF
--- a/gtests/src/integration/integration.cpp
+++ b/gtests/src/integration/integration.cpp
@@ -208,6 +208,7 @@ std::string Integration::default_keyspace() {
 
   // Clean up the initial keyspace name (remove category information)
   keyspace_name_ = to_lower(test_case_name_) + "_" + to_lower(test_name_);
+  keyspace_name_ = replace_all(keyspace_name_, "tests", ""); //TODO: Rename integration tests (remove 's' or add 's')
   keyspace_name_ = replace_all(keyspace_name_, "test", "");
   keyspace_name_ = replace_all(keyspace_name_, "integration", "");
   for (TestCategory::iterator iterator = TestCategory::begin();
@@ -267,7 +268,9 @@ std::string Integration::default_table() {
   if (!table_name_.empty()) {
     return table_name_;
   }
+
   table_name_ = to_lower(test_name_);
+  table_name_ = replace_all(table_name_, "integration_", "");
   maybe_shrink_name(table_name_);
   return table_name_;
 }

--- a/gtests/src/integration/integration.hpp
+++ b/gtests/src/integration/integration.hpp
@@ -70,14 +70,19 @@
   }
 
 #define SKIP_TEST_VERSION(server_version_string, version_string) \
-  SKIP_TEST("Unsupported for Server Version " \
-  << server_version_string << ": Server version " \
-  << version_string << "+ is required")
+  SKIP_TEST("Unsupported for Apache Cassandra Version " \
+    << server_version_string << ": Server version " \
+    << version_string << "+ is required")
 
-#define CHECK_VERSION(version) \
-  if (this->server_version_ < #version) { \
-    SKIP_TEST_VERSION(this->server_version_.to_string(), #version) \
-  }
+#define CHECK_VERSION(version) do { \
+  CCM::CassVersion cass_version = this->server_version_; \
+  if (Options::is_dse()) { \
+    cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version(); \
+  } \
+  if (cass_version < #version) { \
+    SKIP_TEST_VERSION(cass_version.to_string(), #version) \
+  } \
+} while(0)
 
 #define CHECK_OPTIONS_VERSION(version) \
   if (Options::server_version() < #version) { \

--- a/gtests/src/integration/objects/cluster.hpp
+++ b/gtests/src/integration/objects/cluster.hpp
@@ -227,6 +227,20 @@ public:
   }
 
   /**
+   * Enable NO_COMPACT in the STARTUP OPTIONS for the connection
+   *
+   * @param enable True if NO_COMPACT should be enable; false otherwise
+   *              (default: true)
+   * @return Cluster object
+   */
+  Cluster& with_no_compact(bool enable = true) {
+    EXPECT_EQ(CASS_OK,
+              cass_cluster_set_no_compact(get(),
+                                          enable == true ? cass_true : cass_false));
+    return *this;
+  }
+
+  /**
    * Sets the port
    *
    * @param port Port number to set

--- a/gtests/src/integration/options.cpp
+++ b/gtests/src/integration/options.cpp
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <iostream>
 
-#define DEFAULT_OPTIONS_CASSSANDRA_VERSION CCM::CassVersion("3.11.1")
-#define DEFAULT_OPTIONS_DSE_VERSION CCM::DseVersion("5.1.5")
+#define DEFAULT_OPTIONS_CASSSANDRA_VERSION CCM::CassVersion("3.11.2")
+#define DEFAULT_OPTIONS_DSE_VERSION CCM::DseVersion("5.1.7")
 
 // Initialize the defaults for all the options
 bool Options::is_initialized_ = false;

--- a/gtests/src/integration/tests/test_null_string_params.cpp
+++ b/gtests/src/integration/tests/test_null_string_params.cpp
@@ -307,7 +307,7 @@ CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, TableMetaFunctions) {
  * @expected_result Null for each lookup, since no object has a null name.
  */
 CASSANDRA_INTEGRATION_TEST_F(SchemaNullStringApiArgsTest, MaterializedViewMetaFunctions) {
-  CHECK_VERSION(3.0.0)
+  CHECK_VERSION(3.0.0);
 
   const CassMaterializedViewMeta *view_meta =
     cass_table_meta_materialized_view_by_name(table_meta_.get(), VIEW_NAME);

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -1865,6 +1865,28 @@ CASS_EXPORT CassError
 cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
                                            cass_bool_t enabled);
 
+/**
+ * Enable the <b>NO_COMPACT</b> startup option.
+ *
+ * This can help facilitate uninterrupted cluster upgrades where tables using
+ * <b>COMPACT_STORAGE</b> will operate in "compatibility mode" for
+ * <b>BATCH</b>, <b>DELETE</b>, <b>SELECT</b>, and <b>UPDATE</b> CQL operations.
+ *
+ * <b>Default:</b> cass_false
+ *
+ * @cassandra{3.0.16+}
+ * @cassandra{3.11.2+}
+ * @cassandra{4.0+}
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] enabled
+ */
+CASS_EXPORT CassError
+cass_cluster_set_no_compact(CassCluster* cluster,
+                            cass_bool_t enabled);
+
 /***********************************************************************************
  *
  * Session

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -465,6 +465,13 @@ CassError cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
   return CASS_OK;
 }
 
+CassError cass_cluster_set_no_compact(CassCluster* cluster,
+                                 cass_bool_t enabled) {
+  cluster->config().set_no_compact(enabled == cass_true);
+  return CASS_OK;
+}
+
+
 void cass_cluster_free(CassCluster* cluster) {
   delete cluster->from();
 }

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -80,7 +80,8 @@ public:
       , use_schema_(true)
       , use_randomized_contact_points_(true)
       , prepare_on_all_hosts_(true)
-      , prepare_on_up_or_add_host_(true) { }
+      , prepare_on_up_or_add_host_(true)
+      , no_compact_(false) { }
 
   Config new_instance() const {
     Config config = *this;
@@ -394,6 +395,12 @@ public:
     prepare_on_up_or_add_host_ = enabled;
   }
 
+  bool no_compact() const { return no_compact_; }
+
+  void set_no_compact(bool enabled) {
+    no_compact_ = enabled;
+  }
+
 private:
   int port_;
   int protocol_version_;
@@ -441,6 +448,7 @@ private:
   bool use_randomized_contact_points_;
   bool prepare_on_all_hosts_;
   bool prepare_on_up_or_add_host_;
+  bool no_compact_;
 };
 
 } // namespace cass

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -794,7 +794,7 @@ void Connection::on_supported(ResponseMessage* response) {
 
   internal_write(RequestCallback::Ptr(
                    new StartupCallback(Request::ConstPtr(
-                                         new StartupRequest()))));
+                                         new StartupRequest(config().no_compact())))));
 }
 
 void Connection::on_pending_schema_agreement(Timer* timer) {

--- a/src/startup_request.cpp
+++ b/src/startup_request.cpp
@@ -39,6 +39,14 @@ int StartupRequest::encode(int version, RequestCallback* callback, BufferVec* bu
     options[key] = version_;
   }
 
+  if (no_compact_enabled_) {
+    const char* key = "NO_COMPACT";
+    const char* value = "true";
+    length += 2 + strlen(key);
+    length += 2 + strlen(value);
+    options[key] = value;
+  }
+
   bufs->push_back(Buffer(length));
   bufs->back().encode_string_map(0, options);
 

--- a/src/startup_request.hpp
+++ b/src/startup_request.hpp
@@ -28,15 +28,15 @@ namespace cass {
 
 class StartupRequest : public Request {
 public:
-  StartupRequest()
+  StartupRequest(bool no_compact_enabled)
       : Request(CQL_OPCODE_STARTUP)
       , version_("3.0.0")
-      , compression_("") {}
-
-  bool encode(size_t reserved, char** output, size_t& size);
+      , compression_("")
+      , no_compact_enabled_(no_compact_enabled) { }
 
   const std::string version() const { return version_; }
   const std::string compression() const { return compression_; }
+  bool no_compact_enabled() const { return no_compact_enabled_; }
 
 private:
   int encode(int version, RequestCallback* callback, BufferVec* bufs) const;
@@ -46,6 +46,7 @@ private:
 
   std::string version_;
   std::string compression_;
+  bool no_compact_enabled_;
 };
 
 } // namespace cass

--- a/test/ccm_bridge/src/bridge.hpp
+++ b/test/ccm_bridge/src/bridge.hpp
@@ -43,8 +43,8 @@ typedef struct _LIBSSH2_CHANNEL LIBSSH2_CHANNEL;
 #endif
 
 // Default values
-#define DEFAULT_CASSANDRA_VERSION CassVersion("3.11.1")
-#define DEFAULT_DSE_VERSION DseVersion("5.1.5")
+#define DEFAULT_CASSANDRA_VERSION CassVersion("3.11.2")
+#define DEFAULT_DSE_VERSION DseVersion("5.1.7")
 #define DEFAULT_USE_GIT false
 #define DEFAULT_USE_INSTALL_DIR false
 #define DEFAULT_USE_DSE false

--- a/test/ccm_bridge/src/cass_version.hpp
+++ b/test/ccm_bridge/src/cass_version.hpp
@@ -461,13 +461,15 @@ namespace CCM {
         return CassVersion("3.0.12-1656");
       } else if (*this == "5.0.9") {
         return CassVersion("3.0.13-1735");
-      } else if ((*this == "5.0.10" || *this >= "5.0.11") && *this < "5.1.0") {
-        if (*this > "5.0.11") {
+      } else if (*this == "5.0.10" || *this == "5.0.11") {
+        return CassVersion("3.0.14-1862");
+      } else if (*this >= "5.0.12" && *this < "5.1.0") {
+        if (*this > "5.0.12") {
           std::cerr << "Cassandra Version is not Defined: "
             << "Add Cassandra version for DSE v" << this->to_string()
             << std::endl;
         }
-        return CassVersion("3.0.14-1862");
+        return CassVersion("3.0.15-2128");
       } else if (*this == "5.1.0") {
         return CassVersion("3.10.0-1652");
       } else if (*this == "5.1.1") {
@@ -476,13 +478,17 @@ namespace CCM {
         return CassVersion("3.11.0-1758");
       } else if (*this == "5.1.3") {
         return CassVersion("3.11.0-1855");
-      } else if ((*this == "5.1.4" || *this >= "5.1.5") && *this < "6.0.0") {
-        if (*this > "5.1.5") {
-          std::cerr << "Cassandra Version is not Defined: "
-                    << "Add Cassandra version for DSE v" << this->to_string()
-                    << std::endl;
-        }
+      } else if (*this == "5.1.4" || *this == "5.1.5") {
         return CassVersion("3.11.0-1900");
+      } else if (*this == "5.1.6") {
+        return CassVersion("3.11.1-2070");
+      } else if (*this >= "5.1.7" && *this < "6.0.0") {
+        if (*this > "5.1.7") {
+          std::cerr << "Cassandra Version is not Defined: "
+            << "Add Cassandra version for DSE v" << this->to_string()
+            << std::endl;
+        }
+        return CassVersion("3.11.1-2130");
       } else  if (*this >= "6.0.0" && *this < "7.0.0") {
         return CassVersion("4.0.0");
       }


### PR DESCRIPTION
Starting with Apache Cassandra v4.0, Thrift and COMPACT STORAGE is no
longer supported. For uninterrupted cluster upgrades, the C/C++ driver
supports the 'NO_COMPACT' startup option. Enabling this feature using
cass_cluster_set_no_compact() will have same effect as
'DROP COMPACT STORAGE', but only for the connected session.