### PR TITLE
CPP-499 allow local bind

### DIFF
--- a/gtests/src/integration/objects/cluster.hpp
+++ b/gtests/src/integration/objects/cluster.hpp
@@ -135,6 +135,19 @@ public:
   }
 
   /**
+   * Assign the local address to bind; passing an empty string will clear
+   * the local address.
+   *
+   * @param name An IP address or hostname
+   * @return Cluster object
+   */
+  Cluster& with_local_address(const std::string& name) {
+    EXPECT_EQ(CASS_OK, cass_cluster_set_local_address(get(),
+      name.c_str()));
+    return *this;
+  }
+
+  /**
    * Assign the number of connections made to each node/server for each
    * connections thread
    *

--- a/gtests/src/integration/tests/test_control_connection.cpp
+++ b/gtests/src/integration/tests/test_control_connection.cpp
@@ -187,6 +187,67 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests, ConnectUsingInvalidPort) {
 }
 
 /**
+ * Perform session connection using invalid local IP address
+ *
+ * This test will attempt to perform a connection using an invalid local IP
+ * address and ensure the control connection is not established against a
+ * single node cluster.
+ *
+ * @test_category control_connection
+ * @since core:1.0.0
+ * @expected_result Control connection will not be established
+ */
+CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests,
+                             ConnectUsingInvalidLocalIpAddress) {
+  CHECK_FAILURE;
+
+  // Attempt to connect to the server using an invalid local IP address
+  logger_.add_critera("Unable to establish a control connection to host " \
+                      "1.1.1.1 because of the following error: Connection " \
+                      "timeout");
+  Cluster cluster = default_cluster().with_local_address("1.1.1.1");
+  try {
+    cluster.connect();
+    FAIL() << "Connection was established using invalid local IP address";
+  } catch (Session::Exception& se) {
+    ASSERT_EQ(CASS_ERROR_LIB_NO_HOSTS_AVAILABLE, se.error_code());
+    ASSERT_GE(logger_.count(), 1u);
+  }
+}
+
+/**
+ * Perform session connection using valid local IP address but invalid
+ * remote address
+ *
+ * This test will attempt to perform a connection using a valid local IP
+ * address and invalid remote address and ensure the control connection is
+ * not established against a single node cluster.
+ *
+ * @test_category control_connection
+ * @since core:1.0.0
+ * @expected_result Control connection will not be established
+ */
+CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests,
+                             ConnectUsingValidLocalIpAddressButInvalidRemote) {
+  CHECK_FAILURE;
+
+  // Attempt to connect to the server using an valid local IP address
+  // but invalid remote address
+  logger_.add_critera("Unable to establish a control connection to host " \
+                      "1.1.1.1 because of the following error: Connection " \
+                      "timeout");
+  Cluster cluster = Cluster::build().with_contact_points("1.1.1.1")
+    .with_local_address("127.0.0.1");
+  try {
+    cluster.connect();
+    FAIL() << "Connection was established using invalid IP address";
+  } catch (Session::Exception& se) {
+    ASSERT_EQ(CASS_ERROR_LIB_NO_HOSTS_AVAILABLE, se.error_code());
+    ASSERT_GE(logger_.count(), 1u);
+  }
+}
+
+/**
  * Perform session connection while forcing a control connection reconnect
  *
  * This test will perform a connection and ensure the control connection

--- a/gtests/src/integration/tests/test_control_connection.cpp
+++ b/gtests/src/integration/tests/test_control_connection.cpp
@@ -234,7 +234,7 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests,
   CHECK_FAILURE;
 
   // Attempt to connect to the server using an unbindable local IP address
-  logger_.add_critera("Unable to bind local address");
+  logger_.add_critera("Unable to bind local address: address not available");
   Cluster cluster = default_cluster().with_local_address("1.1.1.1");
   try {
     cluster.connect();

--- a/gtests/src/integration/tests/test_control_connection.cpp
+++ b/gtests/src/integration/tests/test_control_connection.cpp
@@ -587,6 +587,7 @@ CASSANDRA_INTEGRATION_TEST_F(ControlConnectionTests,
   CHECK_FAILURE;
 
   // Stop the cluster and attempt to perform a request
+  connect();
   ccm_->stop_cluster();
   Result result = session_.execute(SELECT_ALL_SYSTEM_LOCAL_CQL,
                                    CASS_CONSISTENCY_ONE, false, false);

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -947,6 +947,21 @@ cass_cluster_set_port(CassCluster* cluster,
                       int port);
 
 /**
+ * Sets the local address to bind when connecting to the cluster,
+ * if desired.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] name IP address to bind, or empty string for no binding.
+ * Only numeric addresses are supported; no resolution is done.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+CASS_EXPORT CassError
+cass_cluster_set_local_address(CassCluster* cluster,
+                               const char* name);
+
+/**
  * Same as cass_cluster_set_local_address(), but with lengths for string
  * parameters.
  *
@@ -961,23 +976,8 @@ cass_cluster_set_port(CassCluster* cluster,
  */
 CASS_EXPORT CassError
 cass_cluster_set_local_address_n(CassCluster* cluster,
-                      const char* name,
-                      size_t name_length);
-
-/**
- * Sets the local address to bind when connecting to the cluster,
- * if desired.
- *
- * @public @memberof CassCluster
- *
- * @param[in] cluster
- * @param[in] name IP address to bind, or empty string for no binding.
- * Only numeric addresses are supported; no resolution is done.
- * @return CASS_OK if successful, otherwise an error occurred.
- */
-CASS_EXPORT CassError
-cass_cluster_set_local_address(CassCluster* cluster,
-                      const char* name);
+                                 const char* name,
+                                 size_t name_length);
 
 /**
  * Sets the SSL context and enables SSL.

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -971,8 +971,8 @@ cass_cluster_set_local_address_n(CassCluster* cluster,
  * @public @memberof CassCluster
  *
  * @param[in] cluster
- * @param[in] name IP address or hostname to bind, or empty string
- * for no binding.
+ * @param[in] name IP address to bind, or empty string for no binding.
+ * Only numeric addresses are supported; no resolution is done.
  * @return CASS_OK if successful, otherwise an error occurred.
  */
 CASS_EXPORT CassError

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -947,6 +947,39 @@ cass_cluster_set_port(CassCluster* cluster,
                       int port);
 
 /**
+ * Same as cass_cluster_set_local_address(), but with lengths for string
+ * parameters.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] name
+ * @param[in] name_length
+ * @return same as cass_cluster_set_local_address()
+ *
+ * @see cass_cluster_set_local_address()
+ */
+CASS_EXPORT CassError
+cass_cluster_set_local_address_n(CassCluster* cluster,
+                      const char* name,
+                      size_t name_length);
+
+/**
+ * Sets the local address to bind when connecting to the cluster,
+ * if desired.
+ *
+ * @public @memberof CassCluster
+ *
+ * @param[in] cluster
+ * @param[in] name IP address or hostname to bind, or empty string
+ * for no binding.
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+CASS_EXPORT CassError
+cass_cluster_set_local_address(CassCluster* cluster,
+                      const char* name);
+
+/**
  * Sets the SSL context and enables SSL.
  *
  * @public @memberof CassCluster

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -465,6 +465,18 @@ CassError cass_cluster_set_prepare_on_up_or_add_host(CassCluster* cluster,
   return CASS_OK;
 }
 
+CassError cass_cluster_set_local_address(CassCluster* cluster,
+                                                     const char* name) {
+  return cass_cluster_set_local_address_n(cluster, name, SAFE_STRLEN(name));
+}
+
+CassError cass_cluster_set_local_address_n(CassCluster* cluster,
+                                                     const char* name,
+                                                     size_t name_length) {
+  cluster->config().set_local_address(std::string(name, name_length));
+  return CASS_OK;
+}
+
 CassError cass_cluster_set_no_compact(CassCluster* cluster,
                                  cass_bool_t enabled) {
   cluster->config().set_no_compact(enabled == cass_true);

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -473,7 +473,13 @@ CassError cass_cluster_set_local_address(CassCluster* cluster,
 CassError cass_cluster_set_local_address_n(CassCluster* cluster,
                                                      const char* name,
                                                      size_t name_length) {
-  cluster->config().set_local_address(std::string(name, name_length));
+  cass::Address address;
+  if (name_length == 0 ||
+      cass::Address::from_string(std::string(name, name_length), 0, &address)) {
+    cluster->config().set_local_address(address);
+  } else {
+    return CASS_ERROR_LIB_HOST_RESOLUTION;
+  }
   return CASS_OK;
 }
 

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -473,8 +473,9 @@ CassError cass_cluster_set_local_address(CassCluster* cluster,
 CassError cass_cluster_set_local_address_n(CassCluster* cluster,
                                                      const char* name,
                                                      size_t name_length) {
-  cass::Address address;
+  cass::Address address;  // default to AF_UNSPEC
   if (name_length == 0 ||
+      name == NULL ||
       cass::Address::from_string(std::string(name, name_length), 0, &address)) {
     cluster->config().set_local_address(address);
   } else {

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -81,7 +81,6 @@ public:
       , use_randomized_contact_points_(true)
       , prepare_on_all_hosts_(true)
       , prepare_on_up_or_add_host_(true)
-      , local_address_("")
       , no_compact_(false) { }
 
   Config new_instance() const {
@@ -396,10 +395,11 @@ public:
     prepare_on_up_or_add_host_ = enabled;
   }
 
-  const std::string& local_address() const { return local_address_; }
+  const Address* local_address() const {
+    return local_address_.is_valid() ? &local_address_ : NULL; }
 
-  void set_local_address(const std::string& name) {
-    local_address_ = name;
+  void set_local_address(const Address& address) {
+    local_address_ = address;
   }
 
   bool no_compact() const { return no_compact_; }
@@ -455,7 +455,7 @@ private:
   bool use_randomized_contact_points_;
   bool prepare_on_all_hosts_;
   bool prepare_on_up_or_add_host_;
-  std::string local_address_;
+  Address local_address_;
   bool no_compact_;
 };
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -81,6 +81,7 @@ public:
       , use_randomized_contact_points_(true)
       , prepare_on_all_hosts_(true)
       , prepare_on_up_or_add_host_(true)
+      , local_address_("")
       , no_compact_(false) { }
 
   Config new_instance() const {
@@ -395,6 +396,12 @@ public:
     prepare_on_up_or_add_host_ = enabled;
   }
 
+  const std::string& local_address() const { return local_address_; }
+
+  void set_local_address(const std::string& name) {
+    local_address_ = name;
+  }
+
   bool no_compact() const { return no_compact_; }
 
   void set_no_compact(bool enabled) {
@@ -448,6 +455,7 @@ private:
   bool use_randomized_contact_points_;
   bool prepare_on_all_hosts_;
   bool prepare_on_up_or_add_host_;
+  std::string local_address_;
   bool no_compact_;
 };
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -232,7 +232,6 @@ Connection::Connection(uv_loop_t* loop,
     , heartbeat_outstanding_(false) {
   socket_.data = this;
   uv_tcp_init(loop_, &socket_);
-  bool ok = true;
 
   if (uv_tcp_nodelay(&socket_,
                      config.tcp_nodelay_enable() ? 1 : 0) != 0) {
@@ -249,16 +248,14 @@ Connection::Connection(uv_loop_t* loop,
   if (local_address) {
     int rc = uv_tcp_bind(&socket_, local_address->addr(), 0);
     if (rc) {
-      ok = false;
       notify_error("Unable to bind local address: " + std::string(UV_ERRSTR(rc, loop_)));
+      return;
     }
   }
 
-  if (ok) {
-    SslContext* ssl_context = config_.ssl_context();
-    if (ssl_context != NULL) {
-      ssl_session_.reset(ssl_context->create_session(host));
-    }
+  SslContext* ssl_context = config_.ssl_context();
+  if (ssl_context != NULL) {
+    ssl_session_.reset(ssl_context->create_session(host));
   }
 }
 

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -247,9 +247,10 @@ Connection::Connection(uv_loop_t* loop,
 
   const Address* local_address = config_.local_address();
   if (local_address) {
-    if (uv_tcp_bind(&socket_, local_address->addr(), 0)) {
+    int rc = uv_tcp_bind(&socket_, local_address->addr(), 0);
+    if (rc) {
       ok = false;
-      notify_error("Unable to bind local address");
+      notify_error("Unable to bind local address: " + std::string(UV_ERRSTR(rc, loop_)));
     }
   }
 


### PR DESCRIPTION
Fix https://datastax-oss.atlassian.net/browse/CPP-499, i.e., add `cass_cluster_set_local_address` to allow clients to bind a local IP address before connecting to Cassandra. This is important for hosts using multiple network interfaces with strict network separation requirements.