### PR TITLE
Fixed dch utility package name

### DIFF
--- a/packaging/build_deb.sh
+++ b/packaging/build_deb.sh
@@ -25,7 +25,7 @@ EOF
   echo "$version"
 }
 
-check_command "dch" "debhelper"
+check_command "dch" "devscripts"
 check_command "lsb_release" "lsb-release"
 
 version=$(header_version "../include/cassandra.h")


### PR DESCRIPTION
dch utility is placed in devscripts package, not in debhelper