### PR TITLE
Use uv/version.h as version file for libuv-1.21.0

### DIFF
--- a/cmake/modules/CppDriver.cmake
+++ b/cmake/modules/CppDriver.cmake
@@ -372,6 +372,8 @@ macro(CassUseLibuv)
 
   if (EXISTS "${LIBUV_INCLUDE_DIR}/uv-version.h")
     set(LIBUV_VERSION_HEADER_FILE "${LIBUV_INCLUDE_DIR}/uv-version.h")
+  elseif (EXISTS "${LIBUV_INCLUDE_DIR}/uv/version.h")
+    set(LIBUV_VERSION_HEADER_FILE "${LIBUV_INCLUDE_DIR}/uv/version.h")
   else()
     set(LIBUV_VERSION_HEADER_FILE "${LIBUV_INCLUDE_DIR}/uv.h")
   endif()


### PR DESCRIPTION
libuv-1.21.0 changed where the version file gets installed to.