### PR TITLE
Fixing recovery of remote dc host

### DIFF
--- a/src/dc_aware_policy.hpp
+++ b/src/dc_aware_policy.hpp
@@ -79,6 +79,7 @@ private:
 
     void add_host_to_dc(const std::string& dc, const Host::Ptr& host);
     void remove_host_from_dc(const std::string& dc, const Host::Ptr& host);
+    void change_host_status(const std::string& dc, const Host::Ptr& host, Host::HostState state);
     const CopyOnWriteHostVec& get_hosts(const std::string& dc) const;
     void copy_dcs(KeySet* dcs) const;
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -41,6 +41,20 @@ void remove_host(CopyOnWriteHostVec& hosts, const Host::Ptr& host) {
   }
 }
 
+void change_host_status(CopyOnWriteHostVec& hosts, const Host::Ptr& host, Host::HostState state) {
+  HostVec::iterator i;
+  for (i = hosts->begin(); i != hosts->end(); ++i) {
+    if ((*i)->address() == host->address()) {
+      if (state == Host::DOWN) {
+        (*i)->set_down();
+      } else {
+        (*i)->set_up();
+      }
+      break;
+    }
+  }
+}
+
 void Host::LatencyTracker::update(uint64_t latency_ns) {
   uint64_t now = uv_hrtime();
 

--- a/src/host.hpp
+++ b/src/host.hpp
@@ -259,6 +259,7 @@ typedef CopyOnWritePtr<HostVec> CopyOnWriteHostVec;
 
 void add_host(CopyOnWriteHostVec& hosts, const Host::Ptr& host);
 void remove_host(CopyOnWriteHostVec& hosts, const Host::Ptr& host);
+void change_host_status(CopyOnWriteHostVec& hosts, const Host::Ptr& host, Host::HostState state);
 
 } // namespace cass
 


### PR DESCRIPTION
Current implementation of dc_aware_policy removes host at on_down, destroying possibility to recover. The distance function always return CASS_HOST_DISTANCE_IGNORE.