### PR TITLE
CPP-687 - Fix recovery of remote DC host

### DIFF
--- a/gtests/src/unit/mockssandra.cpp
+++ b/gtests/src/unit/mockssandra.cpp
@@ -1807,11 +1807,18 @@ cass::String SchemaChangeEvent::encode(SchemaChangeEvent::Target target, SchemaC
 
 void Cluster::init(AddressGenerator& generator,
                    ClientConnectionFactory& factory,
-                   size_t num_nodes) {
+                   size_t num_nodes_dc1, size_t num_nodes_dc2) {
   MT19937_64 token_rng;
-  for (size_t i = 0; i < num_nodes; ++i) {
+  for (size_t i = 0; i < num_nodes_dc1; ++i) {
     Address address(generator.next());
     Server server(Host(address, "dc1", "rack1", token_rng),
+                  internal::ServerConnection::Ptr(
+                    Memory::allocate<internal::ServerConnection>(address, factory)));
+    servers_.push_back(server);
+  }
+  for (size_t i = 0; i < num_nodes_dc2; ++i) {
+    Address address(generator.next());
+    Server server(Host(address, "dc2", "rack1", token_rng),
                   internal::ServerConnection::Ptr(
                     Memory::allocate<internal::ServerConnection>(address, factory)));
     servers_.push_back(server);

--- a/gtests/src/unit/mockssandra.cpp
+++ b/gtests/src/unit/mockssandra.cpp
@@ -1807,7 +1807,8 @@ cass::String SchemaChangeEvent::encode(SchemaChangeEvent::Target target, SchemaC
 
 void Cluster::init(AddressGenerator& generator,
                    ClientConnectionFactory& factory,
-                   size_t num_nodes_dc1, size_t num_nodes_dc2) {
+                   size_t num_nodes_dc1,
+                   size_t num_nodes_dc2) {
   MT19937_64 token_rng;
   for (size_t i = 0; i < num_nodes_dc1; ++i) {
     Address address(generator.next());

--- a/gtests/src/unit/mockssandra.hpp
+++ b/gtests/src/unit/mockssandra.hpp
@@ -1119,7 +1119,8 @@ class Cluster {
 protected:
   void init(AddressGenerator& generator,
             ClientConnectionFactory& factory,
-            size_t num_nodes_dc1, size_t num_nodes_dc2);
+            size_t num_nodes_dc1,
+            size_t num_nodes_dc2);
 
 public:
   ~Cluster();
@@ -1187,7 +1188,8 @@ public:
 class SimpleCluster : public Cluster {
 public:
   SimpleCluster(const RequestHandler* request_handler,
-                size_t num_nodes_dc1 = 1, size_t num_nodes_dc2 = 0)
+                size_t num_nodes_dc1 = 1,
+                size_t num_nodes_dc2 = 0)
     : factory_(request_handler, this)
     , event_loop_group_(1) {
     init(generator_, factory_, num_nodes_dc1, num_nodes_dc2);

--- a/gtests/src/unit/mockssandra.hpp
+++ b/gtests/src/unit/mockssandra.hpp
@@ -1119,7 +1119,7 @@ class Cluster {
 protected:
   void init(AddressGenerator& generator,
             ClientConnectionFactory& factory,
-            size_t num_nodes);
+            size_t num_nodes_dc1, size_t num_nodes_dc2);
 
 public:
   ~Cluster();
@@ -1187,10 +1187,10 @@ public:
 class SimpleCluster : public Cluster {
 public:
   SimpleCluster(const RequestHandler* request_handler,
-                size_t num_nodes = 1)
+                size_t num_nodes_dc1 = 1, size_t num_nodes_dc2 = 0)
     : factory_(request_handler, this)
     , event_loop_group_(1) {
-    init(generator_, factory_, num_nodes);
+    init(generator_, factory_, num_nodes_dc1, num_nodes_dc2);
   }
 
   ~SimpleCluster() {

--- a/gtests/src/unit/tests/test_cluster.cpp
+++ b/gtests/src/unit/tests/test_cluster.cpp
@@ -751,7 +751,7 @@ TEST_F(ClusterUnitTest, DCAwareRecoverOnRemoteHost) {
 
   ASSERT_EQ(listener->connected_hosts().size(), 2u);
   EXPECT_EQ(listener->connected_hosts()[0]->address(), Address("127.0.0.1", PORT));
-  EXPECT_EQ(listener->connected_hosts()[1]->address(), Address("127.0.0.2", PORT)); // Connected to remove host.
+  EXPECT_EQ(listener->connected_hosts()[1]->address(), Address("127.0.0.2", PORT)); // Connected to remote host.
 }
 
 TEST_F(ClusterUnitTest, InvalidDC) {

--- a/gtests/src/unit/tests/test_cluster.cpp
+++ b/gtests/src/unit/tests/test_cluster.cpp
@@ -742,7 +742,7 @@ TEST_F(ClusterUnitTest, DCAwareRecoverOnRemoteHost) {
   ASSERT_TRUE(up_future->wait_for(WAIT_FOR_TIME));
   EXPECT_EQ(remote_address, listener->address());
 
-  cluster.stop(1); // Stop local node to very that remote host is tried for reconnection.
+  cluster.stop(1); // Stop local node to verify that remote host is tried for reconnection.
 
   ASSERT_TRUE(recover_future->wait_for(WAIT_FOR_TIME));
 
@@ -767,7 +767,7 @@ TEST_F(ClusterUnitTest, InvalidDC) {
                                                                      bind_callback(on_connection_connected, connect_future.get())));
 
   ClusterSettings settings;
-  settings.load_balancing_policy.reset(Memory::allocate<DCAwarePolicy>("dc3", 0, false)); // Invalid DC and no using remote hosts
+  settings.load_balancing_policy.reset(Memory::allocate<DCAwarePolicy>("invalid_dc", 0, false)); // Invalid DC and not using remote hosts
   settings.load_balancing_policies.clear();
   settings.load_balancing_policies.push_back(settings.load_balancing_policy);
 

--- a/gtests/src/unit/tests/test_cluster.cpp
+++ b/gtests/src/unit/tests/test_cluster.cpp
@@ -743,7 +743,6 @@ TEST_F(ClusterUnitTest, DCAwareRecoverOnRemoteHost) {
   EXPECT_EQ(remote_address, listener->address());
 
   cluster.stop(1); // Stop local node to verify that remote host is tried for reconnection.
-
   ASSERT_TRUE(recover_future->wait_for(WAIT_FOR_TIME));
 
   connect_future->cluster()->close();

--- a/src/cluster.hpp
+++ b/src/cluster.hpp
@@ -255,10 +255,17 @@ public:
   void prepared(const String& id,
                 const PreparedMetadata::Entry::Ptr& entry);
 
+  /**
+   * Get available hosts (determined by host distance). This filters out ignored
+   * hosts (*NOT* thread-safe).
+   *
+   * @return A mapping of available hosts.
+   */
+  HostMap available_hosts() const;
+
 public:
   int protocol_version() const { return connection_->protocol_version(); }
   const Host::Ptr& connected_host() const { return connected_host_; }
-  const HostMap& hosts() const { return hosts_; }
   const TokenMap::Ptr& token_map() const { return token_map_; }
 
 private:

--- a/src/cluster_connector.cpp
+++ b/src/cluster_connector.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "cluster_connector.hpp"
+#include "dc_aware_policy.hpp"
 #include "random.hpp"
 #include "round_robin_policy.hpp"
 
@@ -232,10 +233,16 @@ void ClusterConnector::on_connect(ControlConnector* connector) {
 
     ScopedPtr<QueryPlan> query_plan(default_policy->new_query_plan("", NULL, NULL));
     if (!query_plan->compute_next()) { // No hosts in the query plan
-      //TODO(fero): Check for DC aware policy to give more informative message (e.g. invalid DC)
-      on_error(CLUSTER_ERROR_NO_HOSTS_AVAILABLE,
-               "No hosts available for connection using the current load " \
-               "balancing policy(s)");
+      const char* message;
+      if (dynamic_cast<DCAwarePolicy*>(query_plan.get()) != NULL) { // Check if DC-aware
+        message = "No hosts available for control connection using the " \
+                  "DC-aware load balancing policy. " \
+                  "Check to see if the configured local datacenter is valid";
+      } else {
+        message = "No hosts available for the control connection using the " \
+                  "configured load balancing policy";
+      }
+      on_error(CLUSTER_ERROR_NO_HOSTS_AVAILABLE, message);
       return;
     }
 

--- a/src/cluster_connector.cpp
+++ b/src/cluster_connector.cpp
@@ -234,8 +234,8 @@ void ClusterConnector::on_connect(ControlConnector* connector) {
     ScopedPtr<QueryPlan> query_plan(default_policy->new_query_plan("", NULL, NULL));
     if (!query_plan->compute_next()) { // No hosts in the query plan
       const char* message;
-      if (dynamic_cast<DCAwarePolicy*>(query_plan.get()) != NULL) { // Check if DC-aware
-        message = "No hosts available for control connection using the " \
+      if (dynamic_cast<DCAwarePolicy::DCAwareQueryPlan*>(query_plan.get()) != NULL) { // Check if DC-aware
+        message = "No hosts available for the control connection using the " \
                   "DC-aware load balancing policy. " \
                   "Check to see if the configured local datacenter is valid";
       } else {

--- a/src/dc_aware_policy.hpp
+++ b/src/dc_aware_policy.hpp
@@ -93,6 +93,7 @@ private:
   const CopyOnWriteHostVec& get_local_dc_hosts() const;
   void get_remote_dcs(PerDCHostMap::KeySet* remote_dcs) const;
 
+public:
   class DCAwareQueryPlan : public QueryPlan {
   public:
     DCAwareQueryPlan(const DCAwarePolicy* policy,
@@ -111,6 +112,7 @@ private:
     size_t index_;
   };
 
+private:
   String local_dc_;
   size_t used_hosts_per_remote_dc_;
   bool skip_remote_dcs_for_local_cl_;

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -165,7 +165,7 @@ void SessionBase::on_initialize(ClusterConnector* connector) {
     cluster_ = connector->release_cluster();
     on_connect(cluster_->connected_host(),
                cluster_->protocol_version(),
-               cluster_->hosts(),
+               cluster_->available_hosts(),
                cluster_->token_map());
   } else {
     assert(!connector->is_canceled() && "Cluster connection process canceled");


### PR DESCRIPTION
The DC-aware load balancing policy depends on an internal host map to determine host distance. The problem was the host distance was being checked to determine whether a node should be added or marked as up.  This fix always adds and marks hosts up even if they're ignored. The distance is only used to determine if a host should have a connection pool.