### PR TITLE
Fixed libuv library searching

### DIFF
--- a/cmake/modules/FindLibuv.cmake
+++ b/cmake/modules/FindLibuv.cmake
@@ -53,7 +53,7 @@ endif()
 find_library(LIBUV_LIBRARY
   NAMES ${_LIBUV_NAMES}
   ${_LIBUV_ROOT_HINTS_AND_PATHS}
-  PATH_SUFFIXES lib
+  PATH_SUFFIXES lib lib/${CMAKE_LIBRARY_ARCHITECTURE}
   NO_DEFAULT_PATH)
 
 # Extract version number if possible.


### PR DESCRIPTION
Hi,

I try to build the project on Ubuntu 16.04
```
# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04 LTS
Release:	16.04
Codename:	xenial
```
I have installed libuv
```
# dpkg -l | fgrep libuv
ii  libuv1:amd64                     1.8.0-1                               amd64        asynchronous event notification library - runtime library
ii  libuv1-dev:amd64                 1.8.0-1                               amd64        asynchronous event notification library - development files

# dpkg -L libuv1-dev
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/libuv1-dev
/usr/share/doc/libuv1-dev/copyright
/usr/lib
/usr/lib/x86_64-linux-gnu
/usr/lib/x86_64-linux-gnu/libuv.a
/usr/lib/x86_64-linux-gnu/pkgconfig
/usr/lib/x86_64-linux-gnu/pkgconfig/libuv.pc
/usr/include
/usr/include/uv-errno.h
/usr/include/uv-version.h
/usr/include/uv.h
/usr/include/uv-threadpool.h
/usr/include/uv-linux.h
/usr/include/uv-unix.h
/usr/share/doc/libuv1-dev/changelog.Debian.gz
/usr/lib/x86_64-linux-gnu/libuv.so
```
When I try to execute cmake I get the error
```
# cmake .
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- PROJECT version: 2.10.0
-- libuv version: v1.8.0
CMake Error at cmake/modules/CppDriver.cmake:378 (message):
  Unable to Locate libuv: libuv v1.0.0+ is required
Call Stack (most recent call first):
  CMakeLists.txt:84 (CassUseLibuv)

-- Configuring incomplete, errors occurred!
See also "/home/zatsepin/projects/udev109/github/cpp-driver/CMakeFiles/CMakeOutput.log".
```

CMake finds libuv headers but can not find library because /usr/lib/x86_64-linux-gnu/ directory is being not scanned.
Adding ${CMAKE_LIBRARY_ARCHITECTURE} path suffix solves the problem