### PR TITLE
CPP-755 UDT schema metadata not properly populated/updated

### DIFF
--- a/examples/udt/udt.c
+++ b/examples/udt/udt.c
@@ -248,8 +248,6 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
-  schema_meta = cass_session_get_schema_meta(session);
-
   execute_query(session,
                 "CREATE KEYSPACE examples WITH replication = { \
                            'class': 'SimpleStrategy', 'replication_factor': '3' }");
@@ -262,6 +260,8 @@ int main(int argc, char* argv[]) {
 
   execute_query(session,
                 "CREATE TABLE examples.udt (id timeuuid, address frozen<address>, PRIMARY KEY(id))");
+
+  schema_meta = cass_session_get_schema_meta(session);
 
   insert_into_udt(session);
   select_from_udt(session);

--- a/src/control_connector.cpp
+++ b/src/control_connector.cpp
@@ -327,7 +327,7 @@ void ControlConnector::handle_query_schema(SchemaConnectorRequestCallback* callb
   schema_.views = callback->result("views");
   schema_.columns = callback->result("columns");
   schema_.indexes = callback->result("indexes");
-  schema_.user_types = callback->result("types");
+  schema_.user_types = callback->result("user_types");
   schema_.functions = callback->result("functions");
   schema_.aggregates = callback->result("aggregates");
   schema_.virtual_keyspaces = callback->result("virtual_keyspaces");


### PR DESCRIPTION
A typo in `ControlConnection` prevents UDT schema metadata from being
properly updated.