### PR TITLE
Fix generation of shlib deps file for debian packages 

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -32,5 +32,8 @@ override_dh_strip:
 	sed -i s/@DEB_HOST_MULTIARCH@/$(DEB_HOST_MULTIARCH)/ debian/cassandra-cpp-driver-dev/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/*.pc
 	sed -i s/@DEB_VERSION_UPSTREAM@/$(DEB_VERSION_UPSTREAM)/ debian/cassandra-cpp-driver-dev/usr/lib/$(DEB_HOST_MULTIARCH)/pkgconfig/*.pc
 
+override_dh_makeshlibs:
+	dh_makeshlibs -V
+
 override_dh_auto_test:
 override_dh_auto_clean:


### PR DESCRIPTION
Adds current version for correct transitive dependencies.

Without this patch shlib file doesnt contain minimal compatible version of cassandra-cpp-driver and transitive dependencies may be broken.