### PR TITLE
Changed CMAKE_SOURCE_DIR to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6.4)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 # Ensure functions/modules are available
-set(CASS_ROOT_DIR ${CMAKE_SOURCE_DIR})
+set(CASS_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(CASS_SRC_DIR "${CASS_ROOT_DIR}/src")
 set(CASS_INCLUDE_DIR "${CASS_ROOT_DIR}/include")
 list(APPEND CMAKE_MODULE_PATH ${CASS_ROOT_DIR}/cmake/modules)


### PR DESCRIPTION
**Description**
Changing `CMAKE_SOURCE_DIR ` to `CMAKE_CURRENT_SOURCE_DIR` allows the cmake project to be called as a subproject by another parent CMakeLists.txt. If `CMAKE_SOURCE_DIR ` is used, it is _global_ per cmake project and causes all file paths to be wrongly set. 