### PR TITLE
Sort of explicit_bzero proposal.

### DIFF
--- a/cassconfig.hpp.in
+++ b/cassconfig.hpp.in
@@ -12,5 +12,6 @@
 #cmakedefine HAVE_ARC4RANDOM
 #cmakedefine HAVE_GETRANDOM
 #cmakedefine HAVE_TIMERFD
+#cmakedefine HAVE_EXPLICIT_BZERO
 
 #endif

--- a/cmake/modules/CppDriver.cmake
+++ b/cmake/modules/CppDriver.cmake
@@ -1025,6 +1025,7 @@ macro(CassConfigure)
     endif()
   else()
     check_symbol_exists(arc4random_buf "stdlib.h" HAVE_ARC4RANDOM)
+    check_symbol_exists(explicit_bzero "string.h" HAVE_EXPLICIT_BZERO)
   endif()
   # Determine if sigpipe is available
   check_symbol_exists(SO_NOSIGPIPE "sys/socket.h;sys/types.h" HAVE_NOSIGPIPE)

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -11224,6 +11224,17 @@ cass_alloc_set_functions(CassMallocFunction malloc_func,
                          CassReallocFunction realloc_func,
                          CassFreeFunction free_func);
 
+/**
+ * Clean dst buffer to len size
+ *
+ * Similar as bzero but not optimisable regardless
+ * of the compiler optimisation level
+ * @param[in] dst
+ * @param[in] len
+ */
+CASS_EXPORT void
+cass_secure_zero(void * dst,
+		 size_t len);
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -148,7 +148,7 @@ void Md5::final(uint8_t* result) {
   result[14] = d_ >> 16;
   result[15] = d_ >> 24;
 
-  memset(this, 0, sizeof(Md5));
+  cass_secure_zero(this, sizeof(Md5));
 }
 
 // This processes one or more 64-byte data blocks, but does NOT update

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -21,6 +21,17 @@ void cass_alloc_set_functions(CassMallocFunction malloc_func,
   cass::Memory::set_functions(malloc_func, realloc_func, free_func);
 }
 
+void cass_secure_zero(void *dst,
+		      size_t len) {
+#if defined(HAVE_EXPLICIT_BZERO)
+  explicit_bzero(dst, len);
+#else
+  // Using volatile fp over assembly, more portable at least
+  void *(*const volatile nop_memset)(void *, int, size_t) = &memset;
+  nop_memset(dst, 0, len);
+#endif
+}
+
 } // extern "C"
 
 #ifdef DEBUG_CUSTOM_ALLOCATOR


### PR DESCRIPTION
To provide a non optimisable version, compiler-wise, of memset
for security purposes. For now limiting the scope to md5 class.