### PR TITLE
Added helpers for CassConsistency level

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -913,18 +913,22 @@ typedef void(*CassHostListenerCallback)(CassHostListenerEvent event,
  * Gets the next weaker consistency level. Calling this function with the weakest
  * level will return the same value.
  *
+ * @param[in] dc_replication_factor The replication factor used per data center.
  * @param[in] op Indicates if it's a read or write operation.
  * @param[in] stronger The consistency level.
  * @return The next weaker consistency level. If there is a mismatch between the operation
  *         type and the consistency level provided, CASS_CONSISTENCY_UNKNOWN is returned.
  */
 CASS_EXPORT CassConsistency
-cass_next_weaker_consistency_level(CassOperationType op, CassConsistency stronger);
+cass_next_weaker_consistency_level(size_t dc_replication_factor,
+                                   CassOperationType op,
+                                   CassConsistency stronger);
 
 
 /**
  * Compares two consistency levels.
  *
+ * @param[in] dc_replication_factor The replication factor used per data center.
  * @param[in] op Indicates if it's a read or write operation.
  * @param[in] stronger The stronger consistency level.
  * @param[in] weaker The weaker consistency level.
@@ -932,7 +936,10 @@ cass_next_weaker_consistency_level(CassOperationType op, CassConsistency stronge
  *         if one of them is CASS_CONSISTENCY_UNKNOWN, this function returns cass_false.
  */
 CASS_EXPORT cass_bool_t
-cass_consistency_level_compare(CassOperationType op, CassConsistency stronger, CassConsistency weaker);
+cass_consistency_level_compare(size_t dc_replication_factor,
+                               CassOperationType op,
+                               CassConsistency stronger,
+                               CassConsistency weaker);
 
 /***********************************************************************************
  *

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -718,6 +718,11 @@ typedef enum CassError_ {
   /* @endcond*/
 } CassError;
 
+typedef enum CassOperationType_ {
+  CASS_OPERATION_TYPE_READ,
+  CASS_OPERATION_TYPE_WRITE
+} CassOperationType;
+
 /**
  * A callback that's notified when the future is set.
  *
@@ -903,6 +908,31 @@ typedef enum CassHostListenerEvent_ {
 typedef void(*CassHostListenerCallback)(CassHostListenerEvent event,
                                         const CassInet address,
                                         void* data);
+
+/**
+ * Gets the next weaker consistency level. Calling this function with the weakest
+ * level will return the same value.
+ *
+ * @param[in] op Indicates if it's a read or write operation.
+ * @param[in] stronger The consistency level.
+ * @return The next weaker consistency level. If there is a mismatch between the operation
+ *         type and the consistency level provided, CASS_CONSISTENCY_UNKNOWN is returned.
+ */
+CASS_EXPORT CassConsistency
+cass_next_weaker_consistency_level(CassOperationType op, CassConsistency stronger);
+
+
+/**
+ * Compares two consistency levels.
+ *
+ * @param[in] op Indicates if it's a read or write operation.
+ * @param[in] stronger The stronger consistency level.
+ * @param[in] weaker The weaker consistency level.
+ * @return cass_true if 'stronger' is a strictly stronger consistency level. If both levels are equal or
+ *         if one of them is CASS_CONSISTENCY_UNKNOWN, this function returns cass_false.
+ */
+CASS_EXPORT cass_bool_t
+cass_consistency_level_compare(CassOperationType op, CassConsistency stronger, CassConsistency weaker);
 
 /***********************************************************************************
  *


### PR DESCRIPTION
### Description
Added two helper functions for determining the next weaker consistency level and also for comparing two consistency levels. This is very useful when the application needs logic to retry a statement at a lower consistency based on previous failure(s).

New functions added:
1.  `cass_consistency_level_compare()`
2. `cass_next_weaker_consistency_level()`

New enum added:
1. `CassOperationType`

**Note**: This is a preliminary PR as i'm not 100% sure where the function definitions belong to. I put them under `utils.cpp` but they could go in a different location. Also there are no tests yet since I wasn't sure if the PR was going to approved to begin with. I can add some test cases inside `test_consistency.cpp` if need be.
A much simpler way to deal with this would be to re-arrange the `CassConsistency` enums in increasing order, but I feel this would break the API and there might be implementations out there relying on the current hard-coded values, hence these two helper methods.