### PR TITLE
Allow random to work with 0.

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -53,6 +53,11 @@ Random::~Random() { uv_mutex_destroy(&mutex_); }
 
 uint64_t Random::next(uint64_t max) {
   ScopedMutex l(&mutex_);
+
+  if (max == 0) {
+    return 0;
+  }
+
   const uint64_t limit = CASS_UINT64_MAX - CASS_UINT64_MAX % max;
   uint64_t r;
   do {


### PR DESCRIPTION
This doesn't solve the problem of somehow you allow it to initiate with no contact points rather than noop or graceful error (with php-driver try to connect with host as empty string).