### PR TITLE
CPP-754: remove user-defined copy contructors

### DIFF
--- a/src/deque.hpp
+++ b/src/deque.hpp
@@ -28,9 +28,6 @@ public:
   template <class InputIt>
   Deque(InputIt first, InputIt last, const Allocator& alloc = Allocator())
       : std::deque<T, Allocator>(first, last, alloc) {}
-
-  Deque(const Deque& other)
-      : std::deque<T, Allocator>(other) {}
 };
 
 }} // namespace datastax::internal

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -25,9 +25,6 @@ public:
   explicit Map(const Compare& compare = Compare(), const Allocator& alloc = Allocator())
       : std::map<K, V, Compare, Allocator>(compare, alloc) {}
 
-  Map(const Map& other)
-      : std::map<K, V, Compare, Allocator>(other) {}
-
   template <class InputIt>
   Map(InputIt first, InputIt last, const Compare& compare = Compare(),
       const Allocator& alloc = Allocator())

--- a/src/vector.hpp
+++ b/src/vector.hpp
@@ -28,9 +28,6 @@ public:
   explicit Vector(size_t count, const T& value = T())
       : std::vector<T, Allocator>(count, value) {}
 
-  Vector(const Vector& other)
-      : std::vector<T, Allocator>(other) {}
-
   template <class InputIt>
   Vector(InputIt first, InputIt last)
       : std::vector<T, Allocator>(first, last) {}


### PR DESCRIPTION
Under GCC9 `-Werror=deprecated-copy` makes an implicit declaration of
a copy constructor an error if a user-provided one exists.

See also: https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy