### PR TITLE
Add openssl to the required library list in pkg_config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,12 @@ if(CASS_BUILD_STATIC)
   endif()
   CassConfigureStatic("CASS")
 
+  # Set pkg_config required libraries
+  set(PC_REQUIRED_LIBS "libuv")
+  if (CASS_USE_OPENSSL)
+    set(PC_REQUIRED_LIBS "${PC_REQUIRED_LIBS} openssl")
+  endif()
+
   # Update the test flags to indicate the use of the static library
   if(CASS_USE_STATIC_LIBS)
     set(TEST_CXX_FLAGS "${TEST_CXX_FLAGS} -DCASS_STATIC")

--- a/packaging/cassandra_static.pc.in
+++ b/packaging/cassandra_static.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: cassandra
 Description: A C/C++ client driver for Apache Cassandra
 Version: @version@
-Requires: libuv
+Requires: @PC_REQUIRED_LIBS@
 Libs: -L${libdir} -l@PROJECT_LIB_NAME_STATIC@ -lstdc++
 Cflags:
 URL: https://github.com/datastax/cpp-driver/


### PR DESCRIPTION
Add `openssl` to the required library list in pkg_config file when building a static library. Otherwise pkg_config complains if `CASS_USE_OPENSSL` is enabled. Generated .pc file is:

```
prefix=/usr/local
exec_prefix=/usr/local
libdir=/usr/local/lib64
includedir=/usr/local/include/cassandra-datastax

Name: cassandra
Description: A C/C++ client driver for Apache Cassandra
Version: 2.13.0
Requires: libuv openssl
Libs: -L${libdir} -lcassandra_static -lstdc++
Cflags:
URL: https://github.com/datastax/cpp-driver/
```