### PR TITLE
Tampering timing attack with CRYPTO_memcmp usage.

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -371,7 +371,7 @@ private:
         }
 
         if (static_cast<size_t>(ip_len) == addr_buf_size &&
-            memcmp(ip, addr_buf, addr_buf_size) == 0) {
+            CRYPTO_memcmp(ip, addr_buf, addr_buf_size) == 0) {
           result = MATCH;
           break;
         }


### PR DESCRIPTION
even though the name is a bit misleading, closer to bcmp in fact,
also the main difference, it does not stop going through the buffer
upon the first mismatch.