### PR TITLE
cannot link with libcassandra_static.a

### DIFF
--- a/src/third_party/minizip/Makefile.am
+++ b/src/third_party/minizip/Makefile.am
@@ -22,7 +22,7 @@ libminizip_la_SOURCES = \
 	zip.c \
 	${iowin32_src}
 
-libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
+libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz -fPIC
 
 minizip_includedir = $(includedir)/minizip
 minizip_include_HEADERS = \


### PR DESCRIPTION
Hello,

Couldn't find another place to post an issue so here it is.

I'm trying to link the static library into a shared object and I'm getting:
```
/usr/bin/ld: /opt/cpp-driver/lib/libcassandra_static.a(unzip.c.o): relocation R_X86_64_32S against symbol `unz_copyright' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: /opt/cpp-driver/lib/libcassandra_static.a(http_parser.c.o): relocation R_X86_64_32S against `.data' can not be used when making a shared object; recompile with -fPIC
```
where `/opt/cpp-driver` is the installation, `unz_copyright` seems to be a symbol in the `minizip` library and `.data` seems to be a section in `http-parser`, both being third party libraries of `cpp-driver`.

This was possible before 2.14.

The change in this pull request does not fix the issue. It was only a failed attempt, I've included it because there was no other way to open the pull request.

I'm compiling my shared object itself with `-fPIC`.

Do you have any ideas what might be wrong?