### PR TITLE
The Current Release Doesn't Compile with CASS_USE_OPENSSL off

### DIFF
--- a/src/ssl/ssl_no_impl.hpp
+++ b/src/ssl/ssl_no_impl.hpp
@@ -33,7 +33,7 @@ public:
 
 class NoSslContext : public SslContext {
 public:
-  virtual SslSession* create_session(const Address& address, const String& hostname);
+  virtual SslSession* create_session(const Address& address, const String& hostname, const String& sni_server_name);
 
   virtual CassError add_trusted_cert(const char* cert, size_t cert_length);
   virtual CassError set_cert(const char* cert, size_t cert_length);


### PR DESCRIPTION
A silly trivial mistake that somehow made it into the latest release