### PR TITLE
CPP-852 Remove std::ptr_fun<T> and std::not1

### DIFF
--- a/gtests/src/unit/tests/test_utils.cpp
+++ b/gtests/src/unit/tests/test_utils.cpp
@@ -87,3 +87,19 @@ TEST(UtilsUnitTest, NextPow2) {
   EXPECT_EQ(STATIC_NEXT_POW_2(31u), 32u);
   EXPECT_EQ(STATIC_NEXT_POW_2(32u), 32u);
 }
+
+TEST(UtilsUnitTest, Trim) {
+  String s;
+
+  s = " abc";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "abc ";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "  abc  ";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "  a bc ";
+  EXPECT_EQ(trim(s), String("a bc"));
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -104,10 +104,10 @@ String implode(const Vector<String>& vec, const char delimiter /* = ' ' */) {
 String& trim(String& str) {
   // Trim front
   str.erase(str.begin(),
-            std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(::isspace))));
+            std::find_if(str.begin(), str.end(), [](unsigned char c) { return !::isspace(c); }));
   // Trim back
   str.erase(
-      std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(::isspace))).base(),
+      std::find_if(str.rbegin(), str.rend(), [](unsigned char c) { return !::isspace(c); }).base(),
       str.end());
   return str;
 }

--- a/test/integration_tests/src/test_utils.cpp
+++ b/test/integration_tests/src/test_utils.cpp
@@ -538,11 +538,10 @@ void wait_for_node_connections(const std::string& ip_prefix, std::vector<int> no
 std::string& trim(std::string& str) {
   // Trim front
   str.erase(str.begin(),
-            std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(::isspace))));
+            std::find_if(str.begin(), str.end(), [](unsigned char c) { return !::isspace(c); }));
   // Trim back
-  str.erase(
-      std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(::isspace))).base(),
-      str.end());
+  str.erase(std::find_if(str.rbegin(), str.rend(), [](unsigned char c) { return !::isspace(c); }).base(),
+            str.end());
   return str;
 }
 


### PR DESCRIPTION
std::ptr_fun<T> has been deprecated since
C++11, and will be removed in C++17. Compiling
with Clang 10+ will yeild a new error which
is being treated as an error.