### PR TITLE
CPP-852 Remove std::ptr_fun<T> and std::not1

### DIFF
--- a/gtests/src/unit/tests/test_utils.cpp
+++ b/gtests/src/unit/tests/test_utils.cpp
@@ -87,3 +87,19 @@ TEST(UtilsUnitTest, NextPow2) {
   EXPECT_EQ(STATIC_NEXT_POW_2(31u), 32u);
   EXPECT_EQ(STATIC_NEXT_POW_2(32u), 32u);
 }
+
+TEST(UtilsUnitTest, Trim) {
+  String s;
+
+  s = " abc";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "abc ";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "  abc  ";
+  EXPECT_EQ(trim(s), String("abc"));
+
+  s = "  a bc ";
+  EXPECT_EQ(trim(s), String("a bc"));
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,14 +101,13 @@ String implode(const Vector<String>& vec, const char delimiter /* = ' ' */) {
   return str;
 }
 
+static bool not_isspace(int c) { return !::isspace(c); }
+
 String& trim(String& str) {
   // Trim front
-  str.erase(str.begin(),
-            std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(::isspace))));
+  str.erase(str.begin(), std::find_if(str.begin(), str.end(), not_isspace));
   // Trim back
-  str.erase(
-      std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(::isspace))).base(),
-      str.end());
+  str.erase(std::find_if(str.rbegin(), str.rend(), not_isspace).base(), str.end());
   return str;
 }
 

--- a/test/integration_tests/src/test_utils.cpp
+++ b/test/integration_tests/src/test_utils.cpp
@@ -535,14 +535,13 @@ void wait_for_node_connections(const std::string& ip_prefix, std::vector<int> no
   }
 }
 
+static bool not_isspace(int c) { return !::isspace(c); }
+
 std::string& trim(std::string& str) {
   // Trim front
-  str.erase(str.begin(),
-            std::find_if(str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(::isspace))));
+  str.erase(str.begin(), std::find_if(str.begin(), str.end(), not_isspace));
   // Trim back
-  str.erase(
-      std::find_if(str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(::isspace))).base(),
-      str.end());
+  str.erase(std::find_if(str.rbegin(), str.rend(), not_isspace).base(), str.end());
   return str;
 }
 


### PR DESCRIPTION
std::ptr_fun<T> has been deprecated since C++11 [1], and std::not1
has been deprecated since C++17 [2]. Both can be removed without
loosing any functionality.

When using the driver through a package manager you might need to
compile it from source, and this enables the source to be compiled
with -std=c++17.

[1] https://en.cppreference.com/w/cpp/utility/functional/ptr_fun
[2] https://en.cppreference.com/w/cpp/utility/functional/not1