### PR TITLE
CPP-879 Allow remote hosts to come back up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+Unreleased
+===========
+
+Bug Fixes
+--------
+* Allow remote hosts to come back up even if policy ignores down hosts
+
 2.14.0
 ===========
 

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -462,9 +462,7 @@ void RequestProcessor::internal_host_ready(const Host::Ptr& host) {
     LoadBalancingPolicy::Vec policies = load_balancing_policies();
     for (LoadBalancingPolicy::Vec::const_iterator it = policies.begin(); it != policies.end();
          ++it) {
-      if ((*it)->distance(host) != CASS_HOST_DISTANCE_IGNORE) {
-        (*it)->on_host_up(host);
-      }
+      (*it)->on_host_up(host);
     }
   }
 }


### PR DESCRIPTION
When a host comes back up after being down, a request processor (unlike a control connection) only notifies the load balancing policy if the host is not ignored.

Sadly some policies ignore remote hosts that are down.

In combination, this means that remote hosts can never be used by a request (processor) after having once gone down.

This fix resolves this, by always notifying a policy of all host-up events, regardless of the distance of that host.

I've tested this locally, and it has the desired effect. My test case is:
* Start nodes in two datacenters. 
* Set up a token-aware, dc-aware policy.
* Take down the local DC. Observe traffic still goes to the remote DC.
* Take down the remote DC. Observe traffic fails (as expected).
* Bring up the remote DC. Expect traffic will start going to the remote DC.

In the last step, in 2.14.0, instead I observe that traffic continues to fail. Logs and netstat reveal the control connection is up to the remote DC, but it is not used by the request processor. This PR fixes this, so that traffic does go to the remote DC.