### PR TITLE
fix cflags when build with CASS_INSTALL_HEADER_IN_SUBDIR on

### DIFF
--- a/packaging/cassandra.pc.in
+++ b/packaging/cassandra.pc.in
@@ -7,5 +7,5 @@ Name: cassandra
 Description: A C/C++ client driver for Apache Cassandra and DataStax Products
 Version: @version@
 Libs: -L${libdir} -l@PROJECT_LIB_NAME@
-Cflags:
+Cflags: -I${includedir}
 URL: https://github.com/datastax/cpp-driver/

--- a/packaging/cassandra_static.pc.in
+++ b/packaging/cassandra_static.pc.in
@@ -8,5 +8,5 @@ Description: A C/C++ client driver for Apache Cassandra and DataStax Products
 Version: @version@
 Requires: @PC_REQUIRED_LIBS@
 Libs: -L${libdir} -l@PROJECT_LIB_NAME_STATIC@ -lstdc++
-Cflags:
+Cflags: -I${includedir}
 URL: https://github.com/datastax/cpp-driver/


### PR DESCRIPTION
With this patch

```
$ pkg-config cassandra -cflags
-I/usr/include/cassandra 
```