### PR TITLE
CPP-747 fixing inconsistency in USE statements

### DIFF
--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -262,7 +262,7 @@ void Connector::on_ready_or_set_keyspace() {
     finish();
   } else {
     connection_->write_and_flush(RequestCallback::Ptr(
-        new StartupCallback(this, Request::ConstPtr(new QueryRequest("USE " + keyspace_)))));
+        new StartupCallback(this, Request::ConstPtr(new QueryRequest("USE \"" + keyspace_ + "\"")))));
   }
 }
 

--- a/src/prepare_host_handler.cpp
+++ b/src/prepare_host_handler.cpp
@@ -180,7 +180,7 @@ void PrepareHostHandler::PrepareCallback::on_internal_timeout() {
 
 PrepareHostHandler::SetKeyspaceCallback::SetKeyspaceCallback(const String& keyspace,
                                                              const PrepareHostHandler::Ptr& handler)
-    : SimpleRequestCallback(Request::ConstPtr(new QueryRequest("USE " + keyspace)))
+    : SimpleRequestCallback(Request::ConstPtr(new QueryRequest("USE \"" + keyspace + "\"")))
     , handler_(handler) {}
 
 void PrepareHostHandler::SetKeyspaceCallback::on_internal_set(ResponseMessage* response) {

--- a/tests/src/unit/mockssandra.cpp
+++ b/tests/src/unit/mockssandra.cpp
@@ -1810,7 +1810,7 @@ void UseKeyspace::on_run(Request* request) const {
     query.erase(0, query.find_first_not_of(" \t"));
     if (query.substr(0, 3) == "USE" || query.substr(0, 3) == "use") {
       query.erase(0, 3);
-      query.erase(0, query.find_first_not_of(" \t"));
+      query.erase(0, query.find_first_not_of(" \t\""));
       if (query.substr(0, keyspace.size()) == keyspace) {
         String body;
         encode_int32(RESULT_SET_KEYSPACE, &body);


### PR DESCRIPTION
The `USE <keyspace>` statements are inconsistently quoted in different places. It is impossible to use a quoted keyspace (for example keyspace with upper-case characters, see [CPP-747](https://datastax-oss.atlassian.net/browse/CPP-747)). 

This PR fixes a regression from v2.9.0. Keyspaces with uppercases likely never worked since v2.10.0 (9292b536d58c2ce1904afc72fa8be8acd8b9c927). 

This also resolves [PHP-224](https://datastax-oss.atlassian.net/browse/PHP-224).

See these lines:

 - https://github.com/datastax/cpp-driver/blob/bbbbd7bc3eaba1b10ad8ac6f53c41fa93ee718db/src/prepare_host_handler.cpp#L183
 - https://github.com/datastax/cpp-driver/blob/bbbbd7bc3eaba1b10ad8ac6f53c41fa93ee718db/src/pooled_connection.cpp#L40
 - https://github.com/datastax/cpp-driver/blob/bbbbd7bc3eaba1b10ad8ac6f53c41fa93ee718db/src/connector.cpp#L265