### PR TITLE
fix CASS_INSTALL_HEADER_IN_SUBDIR usage

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,7 +233,7 @@ if (CASS_INSTALL_HEADER_IN_SUBDIR)
     set(INSTALL_HEADER_DIR "include/${CASS_INSTALL_HEADER_SUBDIR_NAME}")
   else()
     # Default subdir location is 'include/cassandra'
-    set(INSTALL_HEADER_DIR "include/${PROJECT_NAME_STRING}")
+    set(INSTALL_HEADER_DIR "include/cassandra")
   endif()
 else()
   # Default header install location is 'include'


### PR DESCRIPTION
Since 90a61971299259a8d1e8de7311936b28606ea56b#diff-af3b638bc2a3e6c650974192a53c7291  `PROJECT_NAME_STRING` is no more defined