### PR TITLE
Add cass_ssl_set_default_verify_paths API

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -4679,6 +4679,18 @@ cass_ssl_set_private_key_n(CassSsl* ssl,
                            const char* password,
                            size_t password_length);
 
+/**
+ * Configures the context to use the default directories
+ * for finding certification authority certificates.
+ *
+ * @public @memberof CassSsl
+ *
+ * @param[in] ssl
+ * @return CASS_OK if successful, otherwise an error occurred
+ */
+CASS_EXPORT CassError
+cass_ssl_set_default_verify_paths(CassSsl* ssl);
+
 /***********************************************************************************
  *
  * Authenticator

--- a/src/ssl.cpp
+++ b/src/ssl.cpp
@@ -65,6 +65,10 @@ CassError cass_ssl_set_private_key_n(CassSsl* ssl, const char* key, size_t key_l
   return ssl->set_private_key(key, key_length, password, password_length);
 }
 
+CassError cass_ssl_set_default_verify_paths(CassSsl* ssl) {
+  return ssl->set_default_verify_paths();
+}
+
 } // extern "C"
 
 template <class T>

--- a/src/ssl.hpp
+++ b/src/ssl.hpp
@@ -87,6 +87,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length) = 0;
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length) = 0;
+  virtual CassError set_default_verify_paths() = 0;
 
 protected:
   int verify_flags_;

--- a/src/ssl/ssl_no_impl.cpp
+++ b/src/ssl/ssl_no_impl.cpp
@@ -44,4 +44,8 @@ CassError NoSslContext::set_private_key(const char* key, size_t key_length, cons
   return CASS_ERROR_LIB_NOT_IMPLEMENTED;
 }
 
+CassError NoSslContext::set_default_verify_paths() {
+  return CASS_ERROR_LIB_NOT_IMPLEMENTED;
+}
+
 SslContext::Ptr NoSslContextFactory::create() { return SslContext::Ptr(new NoSslContext()); }

--- a/src/ssl/ssl_no_impl.hpp
+++ b/src/ssl/ssl_no_impl.hpp
@@ -40,6 +40,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length);
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length);
+  virtual CassError set_default_verify_paths();
 };
 
 class NoSslContextFactory : public SslContextFactoryBase<NoSslContextFactory> {

--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -595,6 +595,16 @@ CassError OpenSslContext::set_private_key(const char* key, size_t key_length, co
   return CASS_OK;
 }
 
+CassError OpenSslContext::set_default_verify_paths()
+{
+  int rc = SSL_CTX_set_default_verify_paths(ssl_ctx_);
+  if (!rc) {
+    ssl_log_errors("Unable to load default verification paths");
+    return CASS_ERROR_SSL_INVALID_CERT;
+  }
+  return CASS_OK;
+}
+
 SslContext::Ptr OpenSslContextFactory::create() { return SslContext::Ptr(new OpenSslContext()); }
 
 namespace openssl {

--- a/src/ssl/ssl_openssl_impl.hpp
+++ b/src/ssl/ssl_openssl_impl.hpp
@@ -61,6 +61,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length);
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length);
+  virtual CassError set_default_verify_paths();
 
 private:
   SSL_CTX* ssl_ctx_;

--- a/topics/security/ssl/README.md
+++ b/topics/security/ssl/README.md
@@ -165,6 +165,19 @@ cass_ssl_set_verify_flags(ssl, CASS_SSL_VERIFY_NONE);
 cass_ssl_free(ssl);
 ```
 
+System wide certificate authorities can be enabled as well:
+
+```c
+CassSsl* ssl = cass_ssl_new();
+
+// Use system default directories for finding certificate authorities.
+cass_ssl_set_default_verify_paths(ssl);
+
+/* ... */
+
+cass_ssl_free(ssl);
+```
+
 #### Enabling Cassandra identity verification
 
 If a unique certificate has been generated for each Cassandra node with the IP address or domain name in the CN or SAN fields, you also need to enable identity verification.


### PR DESCRIPTION
Forwards SSL-configuration to use system default directories for finding certificate authorities.

Similar functionality is often desired / provided by similar SSL-context forwarding APIs, e.g. [boost ssl context][boost].

[boost]: https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/reference/ssl__context.html