### PR TITLE
Reach full compatibility with OpenSSL 1.1

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -620,9 +620,11 @@ void free(void* ptr, const char* file, int line) { Memory::free(ptr); }
 void OpenSslContextFactory::internal_init() {
   CRYPTO_set_mem_functions(openssl::malloc, openssl::realloc, openssl::free);
 
+ #if OPENSSL_VERSION_NUMBER < 0x10100000L
   SSL_library_init();
   SSL_load_error_strings();
   OpenSSL_add_all_algorithms();
+  #endif
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
   // We have to set the lock/id callbacks for use of OpenSSL thread safety.
@@ -654,15 +656,19 @@ void OpenSslContextFactory::internal_thread_cleanup() {
 }
 
 void OpenSslContextFactory::internal_cleanup() {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   RAND_cleanup();
   ENGINE_cleanup();
+#endif
   CONF_modules_unload(1);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   CONF_modules_free();
   EVP_cleanup();
   ERR_free_strings();
   CRYPTO_cleanup_all_ex_data();
   CRYPTO_set_locking_callback(NULL);
   CRYPTO_set_id_callback(NULL);
+#endif
 #if OPENSSL_VERSION_NUMBER < 0x10100000L && OPENSSL_VERSION_NUMBER > 0x10002000L
   SSL_COMP_free_compression_methods();
 #endif


### PR DESCRIPTION
Despite what the documentation[1] says the code is not fully compatible
with OpenSSL 1.1 because it relies on compatibility wrappers behind
OPENSSL_API_COMPAT.

The OpenSSL documentation on library initialization[2] explains that
none of the startup fucntions are necessary starting with 1.1. The
changelog for "changes between 1.0.2h and 1.1.0 [25 Aug 2016]"[3]
mentions several removed shutdown functions. The removal of
`CRYPTO_set_locking_callback` is mentioned in a GitHub comment[4].

[1] https://docs.datastax.com/en/developer/cpp-driver/2.15/topics/building/
[2] https://wiki.openssl.org/index.php/Library_Initialization
[3] https://www.openssl.org/news/changelog.html
[4] https://github.com/openssl/openssl/issues/1260#issuecomment-228846202