### PR TITLE
Defunct connection instead of using assertion

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -220,7 +220,9 @@ void Connection::on_write(int status, RequestCallback* request) {
       break;
 
     default:
-      assert(false && "Invalid request state after write finished");
+      LOG_ERROR("Invalid request state %s for stream ID %d", callback->state_string(),
+                callback->stream());
+      defunct();
       break;
   }
 }
@@ -284,7 +286,9 @@ void Connection::on_read(const char* buf, size_t size) {
               break;
 
             default:
-              assert(false && "Invalid request state after receiving response");
+              LOG_ERROR("Invalid request state %s for stream ID %d", callback->state_string(),
+                        response->stream());
+              defunct();
               break;
           }
         } else {

--- a/src/request_callback.cpp
+++ b/src/request_callback.cpp
@@ -172,6 +172,21 @@ void RequestCallback::set_state(RequestCallback::State next_state) {
   }
 }
 
+const char* RequestCallback::state_string() const {
+  switch (state_) {
+    case REQUEST_STATE_NEW:
+      return "NEW";
+    case REQUEST_STATE_WRITING:
+      return "WRITING";
+    case REQUEST_STATE_READING:
+      return "READING";
+    case REQUEST_STATE_READ_BEFORE_WRITE:
+      return "READ_BEFORE_WRITE";
+    case REQUEST_STATE_FINISHED:
+      return "FINISHED";
+  }
+}
+
 SimpleRequestCallback::SimpleRequestCallback(const String& query, uint64_t request_timeout_ms)
     : RequestCallback(
           RequestWrapper(Request::ConstPtr(new QueryRequest(query)), request_timeout_ms)) {}

--- a/src/request_callback.cpp
+++ b/src/request_callback.cpp
@@ -185,6 +185,7 @@ const char* RequestCallback::state_string() const {
     case REQUEST_STATE_FINISHED:
       return "FINISHED";
   }
+  return "INVALID";
 }
 
 SimpleRequestCallback::SimpleRequestCallback(const String& query, uint64_t request_timeout_ms)

--- a/src/request_callback.hpp
+++ b/src/request_callback.hpp
@@ -189,6 +189,8 @@ public:
   State state() const { return state_; }
   void set_state(State next_state);
 
+  const char* state_string() const;
+
   ResponseMessage* read_before_write_response() const { return read_before_write_response_.get(); }
 
   void set_read_before_write_response(ResponseMessage* response) {


### PR DESCRIPTION
Bad data could catch an existing stream in an invalid request state.
It's not the best choice to have an assertion triggered by bad data from
the server-side.