### PR TITLE
Swap multiarch-support for a defensive dependency on libc6

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -13,7 +13,7 @@ Vcs-Browser: https://github.com/datastax/cpp-driver
 Package: cassandra-cpp-driver
 Section: libs
 Architecture: any
-Pre-Depends: multiarch-support, ${misc:Pre-Depends}
+Pre-Depends: libc6 (>= 2.3.6-2), ${misc:Pre-Depends}
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: C/C++ client driver for Apache Cassandra and DataStax Products - runtime library
  A modern, feature-rich, and highly tunable C/C++ client library for Apache


### PR DESCRIPTION
As of Ubuntu Focal Fossa (20.04) the transitional `multiarch-support` package (introduced in Natty Narwhal) has _finally_ been removed.  This MR removes the explicit dependency on that package which unblocks adding a Focal Fossa build of the library.

The details of the change required quite a bit of research so I've written up my findings and logic here:

Back in 2006 glibc added a model for separating 32bit/64bit libraries between separate library paths (`/usr/lib/x86_64-linux-gnu` vs `/usr/lib/i386-linux-gnu`).  Debian (and thus Ubuntu) adopted that policy into their package manager around the time of the Natty Narwhal release, but any packages that used the new paths needed a version of `ld-linux.so` that knew to look in the architecture-specific paths for dynamic libraries.  To make this easier the `multiarch-support` package was added, which is effectively an alias for a dependency on `libc6 >= 2.3.6-2` (since `2.3.6-2` is the version that enabled the multiarch folder searching), the idea being that packages that use the new paths (which in time was expected to be all packages that install libraries) would `Pre-Depend` on `multiarch-support` thereby ensuring that their new libraries would be findable after installation.

Ubuntu releases since Edgy Eft have all provided a new enough `libc6` by standard, so the `multiarch-support` package has been redundant for new installs (since 9 years before it was even created!), but it's been kept around to handle installs that have been upgraded from even older releases to make sure `libc6` is sufficiently upgraded.  As of Focal Fossa this defensive package has been removed (I assume since there's no upgrade path from pre-Dapper Drake that won't sort out the `libc6` versioning at some point).

I considered just removing the dependency outright, but - since in theory it's the "right thing to do" on Xenial Xerus/Bionic Beaver, I instead replaced it with the dependency on the appropriate `libc6` package, which I claim will be a no-op on _every_ install of this package ever 😀.