### PR TITLE
Fix: Only using a single resolved IP when connecting with hostname

### DIFF
--- a/src/resolver.hpp
+++ b/src/resolver.hpp
@@ -73,6 +73,15 @@ public:
 
     inc_ref(); // For the event loop
 
+    // If no hints are provided then use a default filter.
+    struct addrinfo default_hints;
+    if (hints == NULL) {
+      hints = &default_hints;
+      memset(hints, 0, sizeof(struct addrinfo));
+      hints->ai_family = AF_UNSPEC;
+      hints->ai_socktype = SOCK_STREAM;
+    }
+
     if (timeout > 0) {
       timer_.start(loop, timeout, bind_callback(&Resolver::on_timeout, this));
     }

--- a/src/socket_connector.cpp
+++ b/src/socket_connector.cpp
@@ -286,9 +286,10 @@ void SocketConnector::on_resolve(Resolver* resolver) {
     const AddressVec& addresses(resolver->addresses());
     LOG_DEBUG("Resolved the addresses %s for hostname %s", to_string(addresses).c_str(),
               hostname_.c_str());
-    resolved_address_ = Address(
-        addresses[resolved_address_offset_.fetch_add(MEMORY_ORDER_RELAXED) % addresses.size()],
-        address_.server_name()); // Keep the server name for debugging
+
+    size_t offset = resolved_address_offset_.fetch_add(1, MEMORY_ORDER_RELAXED);
+    resolved_address_ = Address(addresses[offset % addresses.size()],
+                                address_.server_name()); // Keep the server name for debugging
     internal_connect(resolver->loop());
   } else if (is_canceled() || resolver->is_canceled()) {
     finish();


### PR DESCRIPTION
`SocketConnector::resolved_address_offset_` is never incremented because
the first parameter was wrong. Also, this adds a default filter for
resolver hints to prevent duplicates in the resolved IPs.