### PR TITLE
Add tsan annotation for atomic_thread_fence

### DIFF
--- a/src/atomic.hpp
+++ b/src/atomic.hpp
@@ -19,6 +19,24 @@
 
 #include "driver_config.hpp"
 
+#if !defined(THREAD_SANITIZER)
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+#define THREAD_SANITIZER 1
+#endif
+#elif defined(__SANITIZE_THREAD__)
+#define THREAD_SANITIZER 1
+#endif
+#endif
+
+// Annotations for atomic_thread_fence, see https://github.com/google/sanitizers/issues/1352
+#ifdef THREAD_SANITIZER
+extern "C" {
+void __tsan_acquire(void* addr);
+void __tsan_release(void* addr);
+}
+#endif
+
 #if defined(HAVE_BOOST_ATOMIC)
 #include "atomic/atomic_boost.hpp"
 #elif defined(HAVE_STD_ATOMIC)

--- a/src/ref_counted.hpp
+++ b/src/ref_counted.hpp
@@ -43,6 +43,9 @@ public:
     assert(new_ref_count >= 1);
     if (new_ref_count == 1) {
       atomic_thread_fence(MEMORY_ORDER_ACQUIRE);
+#ifdef THREAD_SANITIZER
+      __tsan_acquire(const_cast<void*>(static_cast<const void*>(this)));
+#endif
       delete static_cast<const T*>(this);
     }
   }


### PR DESCRIPTION
Thread sanitizer does not support `atomic_thread_fence` with release/acquire order, so using of `atomic_thread_fence(MEMORY_ORDER_ACQUIRE)` in `RefCounted::dec_ref()` causes false positive reports like this: https://gist.github.com/alesapin/96b14caa274a291f12dcf84cddc8ff5c

Explicit annotation avoids such false positives.