### PR TITLE
Fixes for CPP-928, and trusted certs

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -4602,6 +4602,12 @@ cass_ssl_add_trusted_cert_n(CassSsl* ssl,
  * common name or one of its subject alternative names. This implies the
  * certificate is also present. Hostname resolution must also be enabled.
  *
+ * Notes:
+ * - CASS_SSL_VERIFY_PEER_IDENTITY and CASS_SSL_VERIFY_PEER_IDENTITY_DNS are
+ *   mutually exclusive options.
+ * - The certificate Common Name is only checked against the IP address or
+ *   hostname if there are no Subject Alternative Names in the certificate.
+ *
  * <b>Default:</b> CASS_SSL_VERIFY_PEER_CERT
  *
  * @public @memberof CassSsl

--- a/src/address.cpp
+++ b/src/address.cpp
@@ -75,8 +75,9 @@ Address::Address(const uint8_t* address, uint8_t address_length, int port)
   }
 }
 
-Address::Address(const struct sockaddr* addr)
-    : family_(UNRESOLVED)
+Address::Address(const struct sockaddr* addr, const String& server_name)
+    : server_name_(server_name)
+    , family_(UNRESOLVED)
     , port_(0) {
   if (addr->sa_family == AF_INET) {
     const struct sockaddr_in* addr_in = reinterpret_cast<const struct sockaddr_in*>(addr);

--- a/src/address.hpp
+++ b/src/address.hpp
@@ -73,7 +73,7 @@ public:
   Address(const Address& other, const String& server_name);
   Address(const String& hostname_or_address, int port, const String& server_name = String());
   Address(const uint8_t* address, uint8_t address_length, int port);
-  Address(const struct sockaddr* addr);
+  Address(const struct sockaddr* addr, const String& server_name);
 
   bool equals(const Address& other, bool with_port = true) const;
 

--- a/src/client_insights.cpp
+++ b/src/client_insights.cpp
@@ -635,7 +635,7 @@ private:
               new MultiResolver(bind_callback(&StartupMessageHandler::on_resolve, this)));
         }
         resolver->resolve(connection_->loop(), contact_point.hostname_or_address(), port,
-                          config_.resolve_timeout_ms());
+                          config_.resolve_timeout_ms(), contact_point.server_name());
       }
     }
 
@@ -668,7 +668,8 @@ private:
     Address::SocketStorage name;
     int namelen = sizeof(name);
     if (uv_tcp_getsockname(tcp, name.addr(), &namelen) == 0) {
-      Address address(name.addr());
+      // Pass a blank server name as this is a temporary address.
+      Address address(name.addr(), String());
       if (address.is_valid_and_resolved()) {
         return address.to_string();
       }

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -131,7 +131,8 @@ CassError cass_cluster_set_contact_points_n(CassCluster* cluster, const char* co
     explode(String(contact_points, contact_points_length), exploded);
     for (Vector<String>::const_iterator it = exploded.begin(), end = exploded.end(); it != end;
          ++it) {
-      cluster->config().contact_points().push_back(Address(*it, -1));
+      // Treat the address string as the server name.
+      cluster->config().contact_points().push_back(Address(*it, -1, *it));
     }
   }
   return CASS_OK;

--- a/src/cluster_metadata_resolver.cpp
+++ b/src/cluster_metadata_resolver.cpp
@@ -39,13 +39,13 @@ private:
       int port = it->port() <= 0 ? port_ : it->port();
 
       if (it->is_resolved()) {
-        resolved_contact_points_.push_back(Address(it->hostname_or_address(), port));
+        resolved_contact_points_.push_back(Address(it->hostname_or_address(), port, it->server_name()));
       } else {
         if (!resolver_) {
           resolver_.reset(
               new MultiResolver(bind_callback(&DefaultClusterMetadataResolver::on_resolve, this)));
         }
-        resolver_->resolve(loop, it->hostname_or_address(), port, resolve_timeout_ms_);
+        resolver_->resolve(loop, it->hostname_or_address(), port, resolve_timeout_ms_, it->server_name());
       }
     }
 

--- a/src/socket_connector.cpp
+++ b/src/socket_connector.cpp
@@ -120,11 +120,11 @@ void SocketConnector::connect(uv_loop_t* loop) {
     hostname_ = address_.hostname_or_address();
 
     resolver_.reset(new Resolver(hostname_, address_.port(),
-                                 bind_callback(&SocketConnector::on_resolve, this)));
+                                 bind_callback(&SocketConnector::on_resolve, this),
+                                 address_.server_name()));
     resolver_->resolve(loop, settings_.resolve_timeout_ms);
   } else {
     resolved_address_ = address_;
-
     if (settings_.hostname_resolution_enabled) { // Run hostname resolution then connect.
       name_resolver_.reset(
           new NameResolver(address_, bind_callback(&SocketConnector::on_name_resolve, this)));

--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -489,8 +489,8 @@ void OpenSslSession::verify() {
         return;
     }
   } else if (verify_flags_ &
-             CASS_SSL_VERIFY_PEER_IDENTITY_DNS) { // Match using hostnames (including wildcards)
-    switch (OpenSslVerifyIdentity::match_dns(peer_cert, hostname_)) {
+             CASS_SSL_VERIFY_PEER_IDENTITY_DNS) { // Match using the server name (including wildcards)
+    switch (OpenSslVerifyIdentity::match_dns(peer_cert, sni_server_name_)) {
       case OpenSslVerifyIdentity::MATCH:
         // Success
         break;

--- a/tests/src/unit/tests/test_address.cpp
+++ b/tests/src/unit/tests/test_address.cpp
@@ -17,9 +17,11 @@
 #include <gtest/gtest.h>
 
 #include "address.hpp"
+#include "string.hpp"
 
 using datastax::internal::core::Address;
 using datastax::internal::core::AddressSet;
+using datastax::String;
 
 TEST(AddressUnitTest, FromString) {
   EXPECT_TRUE(Address("127.0.0.1", 9042).is_resolved());
@@ -64,14 +66,14 @@ TEST(AddressUnitTest, CompareIPv6) {
 TEST(AddressUnitTest, ToSockAddrIPv4) {
   Address expected("127.0.0.1", 9042);
   Address::SocketStorage storage;
-  Address actual(expected.to_sockaddr(&storage));
+  Address actual(expected.to_sockaddr(&storage), String());
   EXPECT_EQ(expected, actual);
 }
 
 TEST(AddressUnitTest, ToSockAddrIPv6) {
   Address expected("::1", 9042);
   Address::SocketStorage storage;
-  Address actual(expected.to_sockaddr(&storage));
+  Address actual(expected.to_sockaddr(&storage), String());
   EXPECT_EQ(expected, actual);
 }
 

--- a/tests/src/unit/tests/test_resolver.cpp
+++ b/tests/src/unit/tests/test_resolver.cpp
@@ -31,8 +31,9 @@ public:
       : status_(Resolver::NEW) {}
 
   Resolver::Ptr create(const String& hostname, int port = 9042) {
+    // Use the hostname as the TLS server name.
     return Resolver::Ptr(
-        new Resolver(hostname, port, bind_callback(&ResolverUnitTest::on_resolve, this)));
+        new Resolver(hostname, port, bind_callback(&ResolverUnitTest::on_resolve, this), hostname));
   }
 
   MultiResolver::Ptr create_multi() {
@@ -108,9 +109,9 @@ TEST_F(ResolverUnitTest, Cancel) {
 
 TEST_F(ResolverUnitTest, Multi) {
   MultiResolver::Ptr resolver(create_multi());
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
   run_loop();
   ASSERT_EQ(3u, resolvers().size());
   for (Resolver::Vec::const_iterator it = resolvers().begin(), end = resolvers().end(); end != it;
@@ -130,9 +131,9 @@ TEST_F(ResolverUnitTest, MultiTimeout) {
   starve_thread_pool(200);
 
   // Use shortest possible timeout for all requests
-  resolver->resolve(loop(), "localhost", 9042, 1);
-  resolver->resolve(loop(), "localhost", 9042, 1);
-  resolver->resolve(loop(), "localhost", 9042, 1);
+  resolver->resolve(loop(), "localhost", 9042, 1, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, 1, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, 1, "localhost");
 
   run_loop();
   ASSERT_EQ(3u, resolvers().size());
@@ -145,9 +146,9 @@ TEST_F(ResolverUnitTest, MultiTimeout) {
 
 TEST_F(ResolverUnitTest, MultiInvalid) {
   MultiResolver::Ptr resolver(create_multi());
-  resolver->resolve(loop(), "doesnotexist1.dne", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "doesnotexist2.dne", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "doesnotexist3.dne", 9042, RESOLVE_TIMEOUT);
+  resolver->resolve(loop(), "doesnotexist1.dne", 9042, RESOLVE_TIMEOUT, "doesnotexist1.dne");
+  resolver->resolve(loop(), "doesnotexist2.dne", 9042, RESOLVE_TIMEOUT, "doesnotexist2.dne");
+  resolver->resolve(loop(), "doesnotexist3.dne", 9042, RESOLVE_TIMEOUT, "doesnotexist3.dne");
   run_loop();
   ASSERT_EQ(3u, resolvers().size());
   for (Resolver::Vec::const_iterator it = resolvers().begin(), end = resolvers().end(); end != it;
@@ -159,9 +160,9 @@ TEST_F(ResolverUnitTest, MultiInvalid) {
 
 TEST_F(ResolverUnitTest, MultiCancel) {
   MultiResolver::Ptr resolver(create_multi());
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
-  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT);
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
+  resolver->resolve(loop(), "localhost", 9042, RESOLVE_TIMEOUT, "localhost");
   resolver->cancel();
   run_loop();
   ASSERT_EQ(3u, resolvers().size());

--- a/tests/src/unit/tests/test_socket.cpp
+++ b/tests/src/unit/tests/test_socket.cpp
@@ -198,7 +198,8 @@ public:
     } else {
       bool match = false;
       do {
-        Address address(res->ai_addr);
+        // Use a blank server name as it's not needed here.
+        Address address(res->ai_addr, String());
         if (address.is_valid_and_resolved() && address == Address(DNS_IP_ADDRESS, 8888)) {
           match = true;
           break;


### PR DESCRIPTION
This PR consists of two commits:

---

[CPP-928](https://datastax-oss.atlassian.net/browse/CPP-928) Ensure server name information flows through from contact point configuration

Previously during Address name resolution, the server name information for a given Address
was lost. This fix ensures that the server name information flows through during the name
resolution process for a given Address.

---

Iterate over all certificates in a trusted cert BIO, not just the first

Previously the code which loaded a trusted certificate from file only
assumed that there was a single certificate in that file, meaning that 
using a certificate bundle for certificate verification would not work.

This fix allows the driver to read multiple trusted certificates out
of a BIO and provision them in the trusted certificate store.

---

Please let me know if you have any comments!