### PR TITLE
Fix case sensitive identifiers, support quoted&unquoted user provided values

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -178,7 +178,7 @@ void Connection::maybe_set_keyspace(ResponseMessage* response) {
   if (response->opcode() == CQL_OPCODE_RESULT) {
     ResultResponse* result = static_cast<ResultResponse*>(response->response_body().get());
     if (result->kind() == CASS_RESULT_KIND_SET_KEYSPACE) {
-      keyspace_ = result->quoted_keyspace();
+      keyspace_ = result->keyspace().to_string();
     }
   }
 }

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -262,7 +262,7 @@ void Connector::on_ready_or_set_keyspace() {
     finish();
   } else {
     connection_->write_and_flush(RequestCallback::Ptr(
-        new StartupCallback(this, Request::ConstPtr(new QueryRequest("USE " + keyspace_)))));
+        new StartupCallback(this, Request::ConstPtr(new QueryRequest("USE " + escape_id(keyspace_))))));
   }
 }
 

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1724,9 +1724,7 @@ void IndexMetadata::update_legacy(StringRef index_type, const ColumnMetadata* co
 }
 
 String IndexMetadata::target_from_legacy(const ColumnMetadata* column, const Value* options) {
-  String column_name(column->name());
-
-  escape_id(column_name);
+  const String column_name = escape_id(column->name());
 
   if (options != NULL && options->value_type() == CASS_VALUE_TYPE_MAP) {
     MapIterator iterator(options);

--- a/src/pooled_connection.cpp
+++ b/src/pooled_connection.cpp
@@ -36,8 +36,8 @@ public:
 private:
   class SetKeyspaceRequest : public QueryRequest {
   public:
-    SetKeyspaceRequest(const String& keyspace, uint64_t request_timeout_ms)
-        : QueryRequest("USE " + keyspace) {
+    SetKeyspaceRequest(String keyspace, uint64_t request_timeout_ms)
+        : QueryRequest("USE " + escape_id(keyspace)) {
       set_request_timeout_ms(request_timeout_ms);
     }
   };

--- a/src/prepare_host_handler.cpp
+++ b/src/prepare_host_handler.cpp
@@ -180,7 +180,7 @@ void PrepareHostHandler::PrepareCallback::on_internal_timeout() {
 
 PrepareHostHandler::SetKeyspaceCallback::SetKeyspaceCallback(const String& keyspace,
                                                              const PrepareHostHandler::Ptr& handler)
-    : SimpleRequestCallback(Request::ConstPtr(new QueryRequest("USE " + keyspace)))
+    : SimpleRequestCallback(Request::ConstPtr(new QueryRequest("USE " + escape_id(keyspace))))
     , handler_(handler) {}
 
 void PrepareHostHandler::SetKeyspaceCallback::on_internal_set(ResponseMessage* response) {

--- a/src/request_handler.cpp
+++ b/src/request_handler.cpp
@@ -489,7 +489,7 @@ void RequestExecution::notify_result_metadata_changed(const Request* request,
   if (result_response->protocol_version().supports_set_keyspace() && !request->keyspace().empty()) {
     keyspace = request->keyspace();
   } else {
-    keyspace = result_response->quoted_keyspace();
+    keyspace = result_response->keyspace().to_string();
   }
 
   if (request->opcode() == CQL_OPCODE_EXECUTE && result_response->kind() == CASS_RESULT_KIND_ROWS) {
@@ -559,7 +559,7 @@ void RequestExecution::on_result_response(Connection* connection, ResponseMessag
 
     case CASS_RESULT_KIND_SET_KEYSPACE:
       // The response is set after the keyspace is propagated to all threads.
-      request_handler_->notify_keyspace_changed(result->quoted_keyspace(), current_host_,
+      request_handler_->notify_keyspace_changed(result->keyspace().to_string(), current_host_,
                                                 response->response_body());
       break;
 

--- a/src/result_response.hpp
+++ b/src/result_response.hpp
@@ -66,11 +66,6 @@ public:
   StringRef keyspace() const { return keyspace_; }
   StringRef table() const { return table_; }
 
-  String quoted_keyspace() const {
-    String temp(keyspace_.to_string());
-    return escape_id(temp);
-  }
-
   bool metadata_changed() { return new_metadata_id_.size() > 0; }
   StringRef new_metadata_id() const { return new_metadata_id_; }
 

--- a/src/statement.cpp
+++ b/src/statement.cpp
@@ -289,7 +289,7 @@ Statement::Statement(const Prepared* prepared)
   // If the keyspace wasn't explictly set then attempt to set it using the
   // prepared statement's result metadata.
   if (keyspace().empty()) {
-    set_keyspace(prepared->result()->quoted_keyspace());
+    set_keyspace(prepared->result()->keyspace().to_string());
   }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -126,12 +126,12 @@ static bool is_quoted_id(const String& str) {
   return str.empty();
 }
 
-String& escape_id(String& str) { 
+String escape_id(const String& str) {
   // add quotes only to unqoted strings and containing upper case chars
-  if (!is_quoted_id(str) && !is_lowercase(str)) {
-    str = "\"" + str + "\"";
+  if (is_quoted_id(str) || is_lowercase(str)) {
+    return str;
   }
-  return str;
+  return "\"" + str + "\"";
 }
 
 int32_t get_pid() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -116,14 +116,14 @@ static bool is_lowercase(const String& str) {
 }
 
 static bool is_quoted_id(const String& str) {
-  // do not quote blank spaces 
+  // ignore spaces
   String::const_iterator b = std::find_if_not(str.begin(), str.end(), ::isspace);
   if (b != str.end() && *b == '"') {
     String::const_reverse_iterator e = std::find_if_not(str.rbegin(), str.rend(), ::isspace);
     return (*e == '"');
   }
-  // do not quote empty string
-  return str.empty();
+  // do not quote empty, or spaces only  strings
+  return b == str.end() || str.empty();
 }
 
 String escape_id(const String& str) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -101,7 +101,7 @@ String implode(const Vector<String>& vec, const char delimiter /* = ' ' */) {
   return str;
 }
 
-bool not_isspace(int c) { return !::isspace(c); }
+static bool not_isspace(int c) { return !::isspace(c); }
 
 String& trim(String& str) {
   // Trim front
@@ -112,38 +112,27 @@ String& trim(String& str) {
 }
 
 static bool is_lowercase(const String& str) {
-  if (str.empty()) return true;
-
-  char c = str[0];
-  if (!(c >= 'a' && c <= 'z')) return false;
-
-  for (String::const_iterator it = str.begin() + 1, end = str.end(); it != end; ++it) {
-    char c = *it;
-    if (!((c >= '0' && c <= '9') || (c == '_') || (c >= 'a' && c <= 'z'))) {
-      return false;
-    }
-  }
-  return true;
+  return str.end() == std::find_if(str.begin(), str.end(), ::isupper);
 }
 
-static String& quote_id(String& str) {
-  String temp(str);
-  str.clear();
-  str.push_back('"');
-  for (String::const_iterator i = temp.begin(), end = temp.end(); i != end; ++i) {
-    if (*i == '"') {
-      str.push_back('"');
-      str.push_back('"');
-    } else {
-      str.push_back(*i);
-    }
+static bool is_quoted_id(const String& str) {
+  // do not quote blank spaces 
+  String::const_iterator b = std::find_if_not(str.begin(), str.end(), ::isspace);
+  if (b != str.end() && *b == '"') {
+    String::const_reverse_iterator e = std::find_if_not(str.rbegin(), str.rend(), ::isspace);
+    return (*e == '"');
   }
-  str.push_back('"');
+  // do not quote empty string
+  return str.empty();
+}
 
+String& escape_id(String& str) { 
+  // add quotes only to unqoted strings and containing upper case chars
+  if (!is_quoted_id(str) && !is_lowercase(str)) {
+    str = "\"" + str + "\"";
+  }
   return str;
 }
-
-String& escape_id(String& str) { return is_lowercase(str) ? str : quote_id(str); }
 
 int32_t get_pid() {
 #if (defined(WIN32) || defined(_WIN32))

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -69,7 +69,7 @@ String implode(const Vector<String>& vec, const char delimiter = ',');
 
 String& trim(String& str);
 
-String& escape_id(String& str);
+String escape_id(const String& str);
 
 inline size_t num_leading_zeros(int64_t value) {
   if (value == 0) return 64;

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -320,7 +320,7 @@ void Integration::drop_type(const std::string& type_name) {
 
 bool Integration::use_keyspace(const std::string& keyspace_name) {
   std::stringstream use_keyspace_query;
-  use_keyspace_query << "USE " << keyspace_name;
+  use_keyspace_query << "USE " << escape_id(keyspace_name);
   session_.execute(use_keyspace_query.str());
   if (this->HasFailure()) {
     return false;

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -320,7 +320,7 @@ void Integration::drop_type(const std::string& type_name) {
 
 bool Integration::use_keyspace(const std::string& keyspace_name) {
   std::stringstream use_keyspace_query;
-  use_keyspace_query << "USE " << escape_id(keyspace_name);
+  use_keyspace_query << "USE " << keyspace_name;
   session_.execute(use_keyspace_query.str());
   if (this->HasFailure()) {
     return false;

--- a/tests/src/unit/mockssandra.cpp
+++ b/tests/src/unit/mockssandra.cpp
@@ -1819,8 +1819,7 @@ void UseKeyspace::on_run(Request* request) const {
       String keyspace(query.substr(query.find_first_not_of(" \t", 3)));
       for (Vector<String>::const_iterator it = keyspaces.begin(), end = keyspaces.end(); it != end;
            ++it) {
-        String temp(*it);
-        if (keyspace == escape_id(temp)) {
+        if (keyspace == escape_id(*it)) {
           String body;
           encode_int32(RESULT_SET_KEYSPACE, &body);
           encode_string(*it, &body);

--- a/tests/src/unit/tests/test_cluster.cpp
+++ b/tests/src/unit/tests/test_cluster.cpp
@@ -421,7 +421,7 @@ TEST_F(ClusterUnitTest, SimpleWithCriticalFailures) {
 
   connector->with_settings(settings)->connect(event_loop());
 
-  ASSERT_TRUE(connect_future->wait_for(WAIT_FOR_TIME));
+  ASSERT_TRUE(connect_future->wait_for(WAIT_FOR_TIME*2));
   EXPECT_FALSE(connect_future->error());
   EXPECT_GE(
       logging_criteria_count(),

--- a/tests/src/unit/tests/test_utils.cpp
+++ b/tests/src/unit/tests/test_utils.cpp
@@ -29,6 +29,9 @@ using datastax::internal::num_leading_zeros;
 TEST(UtilsUnitTest, EscapeId) {
   String s;
 
+  s = "   ";
+  EXPECT_EQ(escape_id(s), String("   "));
+
   s = "abc";
   EXPECT_EQ(escape_id(s), String("abc"));
 

--- a/tests/src/unit/tests/test_utils.cpp
+++ b/tests/src/unit/tests/test_utils.cpp
@@ -35,11 +35,26 @@ TEST(UtilsUnitTest, EscapeId) {
   s = "aBc";
   EXPECT_EQ(escape_id(s), String("\"aBc\""));
 
+  s = "\"aBc\"";
+  EXPECT_EQ(escape_id(s), String("\"aBc\""));
+
+  s = " \"aBc\" ";
+  EXPECT_EQ(escape_id(s), String(" \"aBc\" "));
+
+  s = "a_c";
+  EXPECT_EQ(escape_id(s), String("a_c"));
+
+  s = "Abc_Def";
+  EXPECT_EQ(escape_id(s), String("\"Abc_Def\""));
+
   s = "\"";
-  EXPECT_EQ(escape_id(s), String("\"\"\"\""));
+  EXPECT_EQ(escape_id(s), String("\""));
+
+  s = "";
+  EXPECT_EQ(escape_id(s), String(""));
 
   s = "a\"Bc";
-  EXPECT_EQ(escape_id(s), String("\"a\"\"Bc\""));
+  EXPECT_EQ(escape_id(s), String("\"a\"Bc\""));
 }
 
 TEST(UtilsUnitTest, NumLeadingZeros) {


### PR DESCRIPTION
Add support for quoted&unquoted user provided keyspaces values, the quoting is automatically handled in the driver.
This makes cpp driver interface usage cleaner, i.e. client code does not have to care about quoting case sensitive keyspace names.

Reason for this fix is, that our backend is passing unquoted keyspace values, as well we had a local fix in connector.cpp similar to what was in  pooled_connection.cpp before the CPP-747 fix, so this is a fix to handle both scenarios.

I have modified quote_id() to cater only for alphanumeric characters and underscores as per https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/valid_literal_r.html, i.e. there is no need to handle quotes in the middle of a string, which would be an invalid identifier. Have updated unit-tests as well.