### PR TITLE
Handle unquoted case sensitive keyspaces

### DIFF
--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1724,9 +1724,7 @@ void IndexMetadata::update_legacy(StringRef index_type, const ColumnMetadata* co
 }
 
 String IndexMetadata::target_from_legacy(const ColumnMetadata* column, const Value* options) {
-  String column_name(column->name());
-
-  escape_id(column_name);
+  const String column_name = escape_id(column->name());
 
   if (options != NULL && options->value_type() == CASS_VALUE_TYPE_MAP) {
     MapIterator iterator(options);

--- a/src/session_base.cpp
+++ b/src/session_base.cpp
@@ -87,7 +87,7 @@ Future::Ptr SessionBase::connect(const Config& config, const String& keyspace) {
   LOG_INFO("Session id is %s", to_string(session_id_).c_str());
 
   config_ = config.new_instance();
-  connect_keyspace_ = keyspace;
+  connect_keyspace_ = escape_id(keyspace);
   connect_future_ = future;
   state_ = SESSION_STATE_CONNECTING;
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -117,9 +117,9 @@ static bool is_lowercase(const String& str) {
 
 static bool is_quoted_id(const String& str) {
   // ignore spaces
-  String::const_iterator b = std::find_if_not(str.begin(), str.end(), ::isspace);
+  String::const_iterator b = std::find_if(str.begin(), str.end(), not_isspace);
   if (b != str.end() && *b == '"') {
-    String::const_reverse_iterator e = std::find_if_not(str.rbegin(), str.rend(), ::isspace);
+    String::const_reverse_iterator e = std::find_if(str.rbegin(), str.rend(), not_isspace);
     return (*e == '"');
   }
   // do not quote empty, or spaces only  strings

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -69,7 +69,7 @@ String implode(const Vector<String>& vec, const char delimiter = ',');
 
 String& trim(String& str);
 
-String& escape_id(String& str);
+String escape_id(const String& str);
 
 inline size_t num_leading_zeros(int64_t value) {
   if (value == 0) return 64;

--- a/tests/src/unit/tests/test_utils.cpp
+++ b/tests/src/unit/tests/test_utils.cpp
@@ -29,17 +29,35 @@ using datastax::internal::num_leading_zeros;
 TEST(UtilsUnitTest, EscapeId) {
   String s;
 
+  s = "   ";
+  EXPECT_EQ(escape_id(s), String("   "));
+
   s = "abc";
   EXPECT_EQ(escape_id(s), String("abc"));
 
   s = "aBc";
   EXPECT_EQ(escape_id(s), String("\"aBc\""));
 
+  s = "\"aBc\"";
+  EXPECT_EQ(escape_id(s), String("\"aBc\""));
+
+  s = " \"aBc\" ";
+  EXPECT_EQ(escape_id(s), String(" \"aBc\" "));
+
+  s = "a_c";
+  EXPECT_EQ(escape_id(s), String("a_c"));
+
+  s = "Abc_Def";
+  EXPECT_EQ(escape_id(s), String("\"Abc_Def\""));
+
   s = "\"";
-  EXPECT_EQ(escape_id(s), String("\"\"\"\""));
+  EXPECT_EQ(escape_id(s), String("\""));
+
+  s = "";
+  EXPECT_EQ(escape_id(s), String(""));
 
   s = "a\"Bc";
-  EXPECT_EQ(escape_id(s), String("\"a\"\"Bc\""));
+  EXPECT_EQ(escape_id(s), String("\"a\"Bc\""));
 }
 
 TEST(UtilsUnitTest, NumLeadingZeros) {


### PR DESCRIPTION
Add support for quoted&unquoted user provided keyspaces values, the quoting is automatically handled in the driver. This makes cpp driver interface usage cleaner, i.e. client code does not have to care about quoting case sensitive keyspace names.

Reason for this fix is, that our backend is passing unquoted keyspace values, as well we had a local fix in connector.cpp similar to what was in pooled_connection.cpp before the CPP-747 fix, so this is a fix to handle both scenarios.

I have modified quote_id() to cater only for alphanumeric characters and underscores as per https://docs.datastax.com/en/cql-oss/3.x/cql/cql_reference/valid_literal_r.html, i.e. there is no need to handle quotes in the middle of a string, which would be an invalid identifier. Have updated unit-tests as well.

This makes **cass_session_connect_keyspace**() accept quoted and unquoted keyspace names.

I have looked as well at:
**cass_data_type_set_keyspace**
**cass_batch_set_keyspace**
**cass_statement_set_keyspace**

but it does not seem that they require any changes
