### PR TITLE
Performance improvement in Decoder::decode_value

### DIFF
--- a/src/collection_iterator.cpp
+++ b/src/collection_iterator.cpp
@@ -36,7 +36,7 @@ bool CollectionIterator::decode_value() {
   }
 
   value_ = decoder_.decode_value(data_type);
-  return !!value_.data_type();
+  return value_.is_valid();
 }
 
 bool TupleIterator::next() {
@@ -46,5 +46,5 @@ bool TupleIterator::next() {
   current_ = next_++;
 
   value_ = decoder_.decode_value(*current_);
-  return !!value_.data_type();
+  return value_.is_valid();
 }

--- a/src/collection_iterator.cpp
+++ b/src/collection_iterator.cpp
@@ -35,7 +35,8 @@ bool CollectionIterator::decode_value() {
     data_type = collection_->primary_data_type();
   }
 
-  return decoder_.decode_value(data_type, value_, true);
+  value_ = decoder_.decode_value(data_type);
+  return !!value_.data_type();
 }
 
 bool TupleIterator::next() {
@@ -43,5 +44,7 @@ bool TupleIterator::next() {
     return false;
   }
   current_ = next_++;
-  return decoder_.decode_value(*current_, value_);
+
+  value_ = decoder_.decode_value(*current_);
+  return !!value_.data_type();
 }

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -147,13 +147,11 @@ Value Decoder::decode_value(const DataType::ConstPtr& data_type) {
     input_ += size;
     remaining_ -= size;
 
-    if (!data_type->is_collection()) {
-      return Value(data_type, decoder);
-    } else {
-      int32_t count = 0;
-      if (!decoder.decode_int32(count)) return Value();
-      return Value(data_type, count, decoder);
+    int32_t count = 0;
+    if (data_type->is_collection() && !decoder.decode_int32(count)) {
+      return Value();
     }
+    return Value(data_type, count, decoder);
   }
   return Value(data_type);
 }

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -138,33 +138,24 @@ bool Decoder::decode_warnings(WarningVec& output) {
   return true;
 }
 
-bool Decoder::decode_value(const DataType::ConstPtr& data_type, Value& output,
-                           bool is_inside_collection /*= false*/) {
-  const char* buffer = NULL;
+Value Decoder::decode_value(const DataType::ConstPtr& data_type) {
   int32_t size = 0;
-
-  if (!decode_int32(size)) {
-    return false;
-  }
+  if (!decode_int32(size)) return Value();
 
   if (size >= 0) {
-    buffer = input_;
+    Decoder decoder(input_, size, protocol_version_);
     input_ += size;
     remaining_ -= size;
-    Decoder decoder(buffer, size, protocol_version_);
 
-    if (data_type->is_collection()) {
-      int32_t count;
-      if (!decoder.decode_int32(count)) return false;
-      output = Value(data_type, count, decoder);
+    if (!data_type->is_collection()) {
+      return Value(data_type, decoder);
     } else {
-      output = Value(data_type, decoder);
+      int32_t count = 0;
+      if (!decoder.decode_int32(count)) return Value();
+      return Value(data_type, count, decoder);
     }
-  } else { // null value
-    output = Value(data_type);
   }
-
-  return true;
+  return Value(data_type);
 }
 
 void Decoder::notify_error(const char* detail, size_t bytes) const {

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -558,7 +558,7 @@ public:
   bool decode_write_type(CassWriteType& output);
   bool decode_warnings(WarningVec& output);
 
-  Value  decode_value(const DataType::ConstPtr& data_type);
+  Value decode_value(const DataType::ConstPtr& data_type);
 
 protected:
   // Testing only

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -558,8 +558,7 @@ public:
   bool decode_write_type(CassWriteType& output);
   bool decode_warnings(WarningVec& output);
 
-  bool decode_value(const DataType::ConstPtr& data_type, Value& output,
-                    bool is_inside_collection = false);
+  Value  decode_value(const DataType::ConstPtr& data_type);
 
 protected:
   // Testing only

--- a/src/map_iterator.cpp
+++ b/src/map_iterator.cpp
@@ -19,8 +19,12 @@
 using namespace datastax::internal::core;
 
 bool MapIterator::decode_pair() {
-  if (!decoder_.decode_value(map_->primary_data_type(), key_, true)) return false;
-  return decoder_.decode_value(map_->secondary_data_type(), value_, true);
+  key_ = decoder_.decode_value(map_->primary_data_type());
+  if (key_.data_type()) {
+    value_ = decoder_.decode_value(map_->secondary_data_type());
+    return !!value_.data_type();
+  }
+  return false;
 }
 
 bool MapIterator::next() {

--- a/src/map_iterator.cpp
+++ b/src/map_iterator.cpp
@@ -22,7 +22,7 @@ bool MapIterator::decode_pair() {
   key_ = decoder_.decode_value(map_->primary_data_type());
   if (key_.data_type()) {
     value_ = decoder_.decode_value(map_->secondary_data_type());
-    return !!value_.data_type();
+    return value_.is_valid();
   }
   return false;
 }

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -49,8 +49,7 @@ const CassValue* cass_row_get_column_by_name_n(const CassRow* row, const char* n
 
 namespace datastax { namespace internal { namespace core {
 
-bool decode_row(Decoder& decoder, const ResultResponse* result,
-                OutputValueVec& output) {
+bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& output) {
   output.clear();
   const int column_count = result->column_count();
   if (column_count > 0) {
@@ -61,7 +60,8 @@ bool decode_row(Decoder& decoder, const ResultResponse* result,
       Value value = decoder.decode_value(def.data_type);
       if (value.data_type()) {
         output.push_back(value);
-      } else return false;
+      } else
+        return false;
     }
   }
   return true;

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -58,7 +58,7 @@ bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& 
     for (int i = 0; i < column_count; ++i) {
       const ColumnDefinition& def = metadata->get_column_definition(i);
       Value value = decoder.decode_value(def.data_type);
-      if (value.data_type()) {
+      if (value.is_valid()) {
         output.push_back(value);
       } else
         return false;

--- a/src/user_type_field_iterator.cpp
+++ b/src/user_type_field_iterator.cpp
@@ -25,5 +25,6 @@ bool UserTypeFieldIterator::next() {
     return false;
   }
   current_ = next_++;
-  return decoder_.decode_value(current_->type, value_);
+  value_ = decoder_.decode_value(current_->type);
+  return !!value_.data_type();
 }

--- a/src/user_type_field_iterator.cpp
+++ b/src/user_type_field_iterator.cpp
@@ -26,5 +26,5 @@ bool UserTypeFieldIterator::next() {
   }
   current_ = next_++;
   value_ = decoder_.decode_value(current_->type);
-  return !!value_.data_type();
+  return value_.is_valid();
 }

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -51,6 +51,8 @@ public:
   ProtocolVersion protocol_version() const { return decoder_.protocol_version(); }
   int64_t size() const { return (is_null_ ? -1 : decoder_.remaining()); }
 
+  bool is_valid() const { return !!data_type_;}
+
   CassValueType value_type() const {
     if (!data_type_) {
       return CASS_VALUE_TYPE_UNKNOWN;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -51,7 +51,7 @@ public:
   ProtocolVersion protocol_version() const { return decoder_.protocol_version(); }
   int64_t size() const { return (is_null_ ? -1 : decoder_.remaining()); }
 
-  bool is_valid() const { return !!data_type_;}
+  bool is_valid() const { return !!data_type_; }
 
   CassValueType value_type() const {
     if (!data_type_) {


### PR DESCRIPTION
Please consider this optimisation, it gives about 39% improvement in **decode_value**, this results in 2-3% improvement in our production backend, which is considerable taking in account the scale of our deployments.

**decode_value** 7.55%, on the right side **Value::operator=** & **Value::~Value**
<img width="1187" alt="Screenshot 2021-04-02 at 12 35 39" src="https://user-images.githubusercontent.com/2941615/113413098-c5164e80-93b1-11eb-9a27-66ff7debb39b.png">

**decode_value** 4.67%
<img width="1189" alt="Screenshot 2021-04-02 at 12 49 19" src="https://user-images.githubusercontent.com/2941615/113413157-dfe8c300-93b1-11eb-8b8b-46e5a86e3147.png">
