### PR TITLE
optimize iteration through collections and UDTs

### DIFF
--- a/src/collection_iterator.cpp
+++ b/src/collection_iterator.cpp
@@ -27,15 +27,14 @@ bool CollectionIterator::next() {
 }
 
 bool CollectionIterator::decode_value() {
-  DataType::ConstPtr data_type;
   if (collection_->value_type() == CASS_VALUE_TYPE_MAP) {
-    data_type =
+    const DataType::ConstPtr& data_type =
         (index_ % 2 == 0) ? collection_->primary_data_type() : collection_->secondary_data_type();
+    value_ = decoder_.decode_value(data_type);
   } else {
-    data_type = collection_->primary_data_type();
+    value_ = decoder_.decode_value(collection_->primary_data_type());
   }
 
-  value_ = decoder_.decode_value(data_type);
   return value_.is_valid();
 }
 

--- a/src/ref_counted.hpp
+++ b/src/ref_counted.hpp
@@ -87,6 +87,19 @@ public:
     return *this;
   }
 
+#if defined(__cpp_rvalue_references)
+  SharedRefPtr<T>& operator=(SharedRefPtr<T>&& ref) noexcept {
+    if (ptr_ != NULL) {
+      ptr_->dec_ref();
+    }
+    ptr_ = ref.ptr_;
+    ref.ptr_ = NULL;
+    return *this;
+  }
+
+  SharedRefPtr(SharedRefPtr<T>&& ref) noexcept : ptr_(ref.ptr_) { ref.ptr_ = NULL; }
+#endif
+
   ~SharedRefPtr() {
     if (ptr_ != NULL) {
       ptr_->dec_ref();

--- a/src/user_type_field_iterator.hpp
+++ b/src/user_type_field_iterator.hpp
@@ -30,9 +30,9 @@ public:
   UserTypeFieldIterator(const Value* user_type_value)
       : Iterator(CASS_ITERATOR_TYPE_USER_TYPE_FIELD)
       , decoder_(user_type_value->decoder()) {
-    UserType::ConstPtr user_type(user_type_value->data_type());
-    next_ = user_type->fields().begin();
-    end_ = user_type->fields().end();
+    const UserType& user_type = static_cast<const UserType&>(*user_type_value->data_type());
+    next_ = user_type.fields().begin();
+    end_ = user_type.fields().end();
   }
 
   virtual bool next();

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -199,11 +199,11 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
     , is_null_(false) {
   assert(!data_type->is_collection());
   if (data_type->is_tuple()) {
-    SharedRefPtr<const CompositeType> composite_type(data_type);
-    count_ = composite_type->types().size();
+    const CompositeType& composite_type = static_cast<const CompositeType&>(*data_type);
+    count_ = composite_type.types().size();
   } else if (data_type->is_user_type()) {
-    UserType::ConstPtr user_type(data_type);
-    count_ = user_type->fields().size();
+    const UserType& user_type = static_cast<const UserType&>(*data_type);
+    count_ = user_type.fields().size();
   } else {
     count_ = 0;
   }


### PR DESCRIPTION
When profiling our application, we noticed  the cpp-driver spends a lot of time in `Decoder::decode_value` method and its callers, and the most hot instructions were connected to `SharedRefPtr<DataType>::inc_ref` and `::dec_ref` methods, i.e. reference counting. Our application mostly reads rows with large collections of UDTs.

This PR avoids SharedRefPtr's copies on several places on the hot path. Note that on some of the places the optimisation relies on move-semantics; as that is available from C++11, the relevant C++11-only code is hidden behind a feature check macro respecting that the codebase targets also older standards.

I've constructed small benchmark which roughly simulates our workload and hence has similar performance profile. The resulting numbers on my machine (WSL, clang10, E5-1620) are:

master branch: 13939 ms
after this PR: 11082 ms

which is approx. 1.25x speedup.

[benchmark used](https://github.com/datastax/cpp-driver/files/6288584/perf.txt) (.txt suffix as github doesn't allow*.c/cpp/cxx...)
