### PR TITLE
Performance improvement reduce Value DataType refcounting

### DIFF
--- a/src/collection_iterator.cpp
+++ b/src/collection_iterator.cpp
@@ -29,7 +29,7 @@ bool CollectionIterator::next() {
 bool CollectionIterator::decode_value() {
   if (collection_->value_type() == CASS_VALUE_TYPE_MAP) {
     const DataType::ConstPtr& data_type =
-        ((index_ & 1) == 0) ? collection_->primary_data_type() : collection_->secondary_data_type();
+        (index_ % 2 == 0) ? collection_->primary_data_type() : collection_->secondary_data_type();
     value_ = decoder_.decode_value(data_type);
   } else {
     value_ = decoder_.decode_value(collection_->primary_data_type());

--- a/src/collection_iterator.cpp
+++ b/src/collection_iterator.cpp
@@ -27,15 +27,14 @@ bool CollectionIterator::next() {
 }
 
 bool CollectionIterator::decode_value() {
-  DataType::ConstPtr data_type;
   if (collection_->value_type() == CASS_VALUE_TYPE_MAP) {
-    data_type =
-        (index_ % 2 == 0) ? collection_->primary_data_type() : collection_->secondary_data_type();
+    const DataType::ConstPtr& data_type =
+        ((index_ & 1) == 0) ? collection_->primary_data_type() : collection_->secondary_data_type();
+    value_ = decoder_.decode_value(data_type);
   } else {
-    data_type = collection_->primary_data_type();
+    value_ = decoder_.decode_value(collection_->primary_data_type());
   }
 
-  value_ = decoder_.decode_value(data_type);
   return value_.is_valid();
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -200,21 +200,21 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
     , decoder_(decoder)
     , is_null_(false) {
 
-  switch(data_type->value_type()) {
-  case CASS_VALUE_TYPE_TUPLE: {
-    SharedRefPtr<const CompositeType> composite_type(data_type);
-    count_ = composite_type->types().size();
-    break;
-  }
-  case CASS_VALUE_TYPE_UDT: {
-    UserType::ConstPtr user_type(data_type);
-    count_ = user_type->fields().size();
-    break;
-  }
-  default:
-    assert(!data_type->is_collection());
-    count_ = 0;
-    break;
+  switch (data_type->value_type()) {
+    case CASS_VALUE_TYPE_TUPLE: {
+      SharedRefPtr<const CompositeType> composite_type(data_type);
+      count_ = composite_type->types().size();
+      break;
+    }
+    case CASS_VALUE_TYPE_UDT: {
+      UserType::ConstPtr user_type(data_type);
+      count_ = user_type->fields().size();
+      break;
+    }
+    default:
+      assert(!data_type->is_collection());
+      count_ = 0;
+      break;
   }
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -192,20 +192,29 @@ CassValueType cass_value_secondary_sub_type(const CassValue* collection) {
 
 } // extern "C"
 
+const DataType::ConstPtr Value::empty_data_type_;
+
 Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
-    : data_type_(data_type)
+    : data_type_(&data_type)
     , count_(0)
     , decoder_(decoder)
     , is_null_(false) {
-  assert(!data_type->is_collection());
-  if (data_type->is_tuple()) {
+
+  switch(data_type->value_type()) {
+  case CASS_VALUE_TYPE_TUPLE: {
     SharedRefPtr<const CompositeType> composite_type(data_type);
     count_ = composite_type->types().size();
-  } else if (data_type->is_user_type()) {
+    break;
+  }
+  case CASS_VALUE_TYPE_UDT: {
     UserType::ConstPtr user_type(data_type);
     count_ = user_type->fields().size();
-  } else {
+    break;
+  }
+  default:
+    assert(!data_type->is_collection());
     count_ = 0;
+    break;
   }
 }
 

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -28,7 +28,8 @@ namespace datastax { namespace internal { namespace core {
 class Value {
 public:
   Value()
-      : count_(0)
+      : data_type_(&empty_data_type_)
+      , count_(0)
       , is_null_(false) {}
 
   // Used for "null" values
@@ -126,7 +127,7 @@ public:
 
 private:
   static const DataType::ConstPtr empty_data_type_;
-  const DataType::ConstPtr* data_type_ = &empty_data_type_;
+  const DataType::ConstPtr* data_type_;
   int32_t count_;
   Decoder decoder_;
   bool is_null_;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -33,7 +33,7 @@ public:
 
   // Used for "null" values
   Value(const DataType::ConstPtr& data_type)
-      : data_type_(data_type)
+      : data_type_(&data_type)
       , count_(0)
       , is_null_(true) {}
 
@@ -42,7 +42,7 @@ public:
 
   // Used for collections and schema metadata collections (converted from JSON)
   Value(const DataType::ConstPtr& data_type, int32_t count, Decoder decoder)
-      : data_type_(data_type)
+      : data_type_(&data_type)
       , count_(count)
       , decoder_(decoder)
       , is_null_(false) {}
@@ -51,30 +51,30 @@ public:
   ProtocolVersion protocol_version() const { return decoder_.protocol_version(); }
   int64_t size() const { return (is_null_ ? -1 : decoder_.remaining()); }
 
-  bool is_valid() const { return !!data_type_; }
+  bool is_valid() const { return !!data_type(); }
 
   CassValueType value_type() const {
-    if (!data_type_) {
-      return CASS_VALUE_TYPE_UNKNOWN;
+    if (data_type()) {
+      return data_type()->value_type();
     }
-    return data_type_->value_type();
+    return CASS_VALUE_TYPE_UNKNOWN;
   }
 
-  const DataType::ConstPtr& data_type() const { return data_type_; }
+  const DataType::ConstPtr& data_type() const { return *data_type_; }
 
   CassValueType primary_value_type() const {
     const DataType::ConstPtr& primary(primary_data_type());
-    if (!primary) {
-      return CASS_VALUE_TYPE_UNKNOWN;
+    if (primary) {
+      return primary->value_type();
     }
-    return primary->value_type();
+    return CASS_VALUE_TYPE_UNKNOWN;
   }
 
   const DataType::ConstPtr& primary_data_type() const {
-    if (!data_type_ || !data_type_->is_collection()) {
+    if (!data_type() || !data_type()->is_collection()) {
       return DataType::NIL;
     }
-    const CollectionType::ConstPtr& collection_type(data_type_);
+    const CollectionType::ConstPtr& collection_type(data_type());
     if (collection_type->types().size() < 1) {
       return DataType::NIL;
     }
@@ -83,17 +83,17 @@ public:
 
   CassValueType secondary_value_type() const {
     const DataType::ConstPtr& secondary(secondary_data_type());
-    if (!secondary) {
-      return CASS_VALUE_TYPE_UNKNOWN;
+    if (secondary) {
+      return secondary->value_type();
     }
-    return secondary->value_type();
+    return CASS_VALUE_TYPE_UNKNOWN;
   }
 
   const DataType::ConstPtr& secondary_data_type() const {
-    if (!data_type_ || !data_type_->is_map()) {
+    if (!data_type() || !data_type()->is_map()) {
       return DataType::NIL;
     }
-    const CollectionType::ConstPtr& collection_type(data_type_);
+    const CollectionType::ConstPtr& collection_type(data_type());
     if (collection_type->types().size() < 2) {
       return DataType::NIL;
     }
@@ -103,23 +103,19 @@ public:
   bool is_null() const { return is_null_; }
 
   bool is_collection() const {
-    if (!data_type_) return false;
-    return data_type_->is_collection();
+    return data_type() && data_type()->is_collection();
   }
 
   bool is_map() const {
-    if (!data_type_) return false;
-    return data_type_->is_map();
+    return data_type() && data_type()->is_map();
   }
 
   bool is_tuple() const {
-    if (!data_type_) return false;
-    return data_type_->is_tuple();
+    return data_type() && data_type()->is_tuple();
   }
 
   bool is_user_type() const {
-    if (!data_type_) return false;
-    return data_type_->is_user_type();
+    return data_type() && data_type()->is_user_type();
   }
 
   int32_t count() const { return count_; }
@@ -137,7 +133,8 @@ public:
   StringVec as_stringlist() const;
 
 private:
-  DataType::ConstPtr data_type_;
+  static const DataType::ConstPtr empty_data_type_;
+  const DataType::ConstPtr* data_type_ = &empty_data_type_;
   int32_t count_;
   Decoder decoder_;
   bool is_null_;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -102,21 +102,13 @@ public:
 
   bool is_null() const { return is_null_; }
 
-  bool is_collection() const {
-    return data_type() && data_type()->is_collection();
-  }
+  bool is_collection() const { return data_type() && data_type()->is_collection(); }
 
-  bool is_map() const {
-    return data_type() && data_type()->is_map();
-  }
+  bool is_map() const { return data_type() && data_type()->is_map(); }
 
-  bool is_tuple() const {
-    return data_type() && data_type()->is_tuple();
-  }
+  bool is_tuple() const { return data_type() && data_type()->is_tuple(); }
 
-  bool is_user_type() const {
-    return data_type() && data_type()->is_user_type();
-  }
+  bool is_user_type() const { return data_type() && data_type()->is_user_type(); }
 
   int32_t count() const { return count_; }
 

--- a/tests/src/unit/tests/test_dse_line_string.cpp
+++ b/tests/src/unit/tests/test_dse_line_string.cpp
@@ -36,8 +36,11 @@ public:
   void TearDown() { dse_line_string_free(line_string); }
 
   const CassValue* to_value() {
+    // Value can not take a temporary for DataType,
+    // normally DataType lifecycle is dictated by the response object
+    static const DataType::ConstPtr data_type(new CustomType(DSE_LINE_STRING_TYPE));
     char* data = const_cast<char*>(reinterpret_cast<const char*>(line_string->bytes().data()));
-    value = Value(DataType::ConstPtr(new CustomType(DSE_LINE_STRING_TYPE)),
+    value = Value(data_type,
                   Decoder(data, line_string->bytes().size(), 0)); // Protocol version not used
     return CassValue::to(&value);
   }

--- a/tests/src/unit/tests/test_dse_polygon.cpp
+++ b/tests/src/unit/tests/test_dse_polygon.cpp
@@ -36,8 +36,11 @@ public:
   void TearDown() { dse_polygon_free(polygon); }
 
   const CassValue* to_value() {
+    // Value can not take a temporary for DataType,
+    // normally DataType lifecycle is dictated by the response object
+    static const DataType::ConstPtr data_type(new CustomType(DSE_POLYGON_TYPE));
     char* data = const_cast<char*>(reinterpret_cast<const char*>(polygon->bytes().data()));
-    value = Value(DataType::ConstPtr(new CustomType(DSE_POLYGON_TYPE)),
+    value = Value(data_type,
                   Decoder(data, polygon->bytes().size(), 0)); // Protocol version not used
     return CassValue::to(&value);
   }

--- a/tests/src/unit/tests/test_dse_polygon.cpp
+++ b/tests/src/unit/tests/test_dse_polygon.cpp
@@ -40,8 +40,8 @@ public:
     // normally DataType lifecycle is dictated by the response object
     static const DataType::ConstPtr data_type(new CustomType(DSE_POLYGON_TYPE));
     char* data = const_cast<char*>(reinterpret_cast<const char*>(polygon->bytes().data()));
-    value = Value(data_type,
-                  Decoder(data, polygon->bytes().size(), 0)); // Protocol version not used
+    value =
+        Value(data_type, Decoder(data, polygon->bytes().size(), 0)); // Protocol version not used
     return CassValue::to(&value);
   }
 


### PR DESCRIPTION
Value object DataType refcounting it is quite a perf hog, this optimisation reduces decode_value() by ~72%, it saves ~20-24% cpu in our backend.

In the shown code path is ~82% saving

decode_value() - 12.8%
<img width="1186" alt="Screenshot 2021-04-27 at 14 51 43" src="https://user-images.githubusercontent.com/2941615/116253171-24c10900-a768-11eb-8d68-3daa44445878.png">

decode_value() - 2.29%
<img width="1189" alt="Screenshot 2021-04-27 at 14 34 47" src="https://user-images.githubusercontent.com/2941615/116250715-e0346e00-a765-11eb-826b-f61f0069333e.png">

Had to change CollectionIterator::decode_value() as it was creating a temporary, DataType::ConstPtr creates a copy, it seems a strange and dangerous behaviour.

I understand that the solution is not pretty, but being unable to use at least c++11, it is the best I could come up with.


