### PR TITLE
Row values decoding performance optimisation

### DIFF
--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -158,6 +158,18 @@ Value Decoder::decode_value(const DataType::ConstPtr& data_type) {
   return Value(data_type);
 }
 
+bool Decoder::decode_value(Value& value) {
+  int32_t size = 0;
+  if (!decode_int32(size)) return false;
+  if (size >= 0) {
+    Decoder decoder(input_, size, protocol_version_);
+    input_ += size;
+    remaining_ -= size;
+    return value.update(decoder);
+  }
+  return false;
+}
+
 void Decoder::notify_error(const char* detail, size_t bytes) const {
   if (strlen(type_) == 0) {
     LOG_ERROR("Expected at least %u byte%s to decode %s value", static_cast<unsigned int>(bytes),

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -158,7 +158,7 @@ Value Decoder::decode_value(const DataType::ConstPtr& data_type) {
   return Value(data_type);
 }
 
-bool Decoder::decode_value(Value& value) {
+bool Decoder::update_value(Value& value) {
   int32_t size = 0;
   if (decode_int32(size)) {
     if (size >= 0) {

--- a/src/decoder.cpp
+++ b/src/decoder.cpp
@@ -160,11 +160,14 @@ Value Decoder::decode_value(const DataType::ConstPtr& data_type) {
 
 bool Decoder::decode_value(Value& value) {
   int32_t size = 0;
-  if (!decode_int32(size)) return false;
-  if (size >= 0) {
-    Decoder decoder(input_, size, protocol_version_);
-    input_ += size;
-    remaining_ -= size;
+  if (decode_int32(size)) {
+    if (size >= 0) {
+      Decoder decoder(input_, size, protocol_version_);
+      input_ += size;
+      remaining_ -= size;
+      return value.update(decoder);
+    }
+    Decoder decoder;
     return value.update(decoder);
   }
   return false;

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -559,6 +559,7 @@ public:
   bool decode_warnings(WarningVec& output);
 
   Value decode_value(const DataType::ConstPtr& data_type);
+  bool decode_value(Value& value);
 
 protected:
   // Testing only

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -561,7 +561,7 @@ public:
   Value decode_value(const DataType::ConstPtr& data_type);
   bool update_value(Value& value);
 
-  bool is_null() const { return input_ == NULL;}
+  bool is_null() const { return input_ == NULL; }
 
 protected:
   // Testing only

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -75,15 +75,6 @@ public:
       , remaining_(length)
       , type_("") {}
 
-  Decoder& operator=(const Decoder& other) {
-    protocol_version_ = other.protocol_version_;
-    input_ = other.input_;
-    length_ = other.length_;
-    remaining_ = other.remaining_;
-    type_ = other.type_;
-    return *this;
-  }
-
   void maybe_log_remaining() const;
 
   inline String as_string() const { return String(input_, remaining_); }
@@ -568,7 +559,7 @@ public:
   bool decode_warnings(WarningVec& output);
 
   Value decode_value(const DataType::ConstPtr& data_type);
-  bool decode_value(Value& value);
+  bool update_value(Value& value);
 
   bool is_null() const { return input_ == NULL;}
 ;

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -75,6 +75,15 @@ public:
       , remaining_(length)
       , type_("") {}
 
+  Decoder& operator=(const Decoder& other) {
+    protocol_version_ = other.protocol_version_;
+    input_ = other.input_;
+    length_ = other.length_;
+    remaining_ = other.remaining_;
+    type_ = other.type_;
+    return *this;
+  }
+
   void maybe_log_remaining() const;
 
   inline String as_string() const { return String(input_, remaining_); }
@@ -561,6 +570,8 @@ public:
   Value decode_value(const DataType::ConstPtr& data_type);
   bool decode_value(Value& value);
 
+  bool is_null() const { return input_ == NULL;}
+;
 protected:
   // Testing only
   inline const char* buffer() const { return input_; }

--- a/src/decoder.hpp
+++ b/src/decoder.hpp
@@ -562,7 +562,7 @@ public:
   bool update_value(Value& value);
 
   bool is_null() const { return input_ == NULL;}
-;
+
 protected:
   // Testing only
   inline const char* buffer() const { return input_; }

--- a/src/result_iterator.hpp
+++ b/src/result_iterator.hpp
@@ -35,17 +35,8 @@ public:
   }
 
   virtual bool next() {
-    if (index_ + 1 >= result_->row_count()) {
-      return false;
-    }
-
-    ++index_;
-
-    if (index_ > 0) {
-      return decode_next_row(decoder_, row_.values);
-    }
-
-    return true;
+    return (index_ + 1 < result_->row_count()) &&
+           (++index < 1 || decode_next_row(decoder_, row_.values));
   }
 
   const Row* row() const {

--- a/src/result_iterator.hpp
+++ b/src/result_iterator.hpp
@@ -31,7 +31,7 @@ public:
       , index_(-1)
       , row_(result) {
     decoder_ = (const_cast<ResultResponse*>(result))->row_decoder();
-    row_.values.reserve(result->column_count());
+    row_.values = result_->first_row().values;
   }
 
   virtual bool next() {
@@ -42,7 +42,7 @@ public:
     ++index_;
 
     if (index_ > 0) {
-      return decode_row(decoder_, result_, row_.values);
+      return decode_next_row(decoder_, row_.values);
     }
 
     return true;
@@ -50,11 +50,7 @@ public:
 
   const Row* row() const {
     assert(index_ >= 0 && index_ < result_->row_count());
-    if (index_ > 0) {
-      return &row_;
-    } else {
-      return &result_->first_row();
-    }
+    return &row_;
   }
 
 private:

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -55,7 +55,10 @@ bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& 
 
     if (size_t(column_count) == output.size()) {
       for (int i = 0; i < column_count; ++i) {
-        if (!decoder.decode_value(output[i])) return false;
+        if (!decoder.decode_value(output[i])) {
+          output.clear();
+          return false;
+        }
       }
       return true;
     }

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -56,7 +56,8 @@ bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& 
     Value value = decoder.decode_value(def.data_type);
     if (value.is_valid()) {
       output.push_back(value);
-    } else return false;
+    } else
+      return false;
   }
   return true;
 }
@@ -67,7 +68,7 @@ bool decode_next_row(Decoder& decoder, OutputValueVec& output) {
     if (!decoder.update_value(output[i])) return false;
   }
   return true;
-} 
+}
 
 }}} // namespace datastax::internal::core
 

--- a/src/row.cpp
+++ b/src/row.cpp
@@ -50,10 +50,17 @@ const CassValue* cass_row_get_column_by_name_n(const CassRow* row, const char* n
 namespace datastax { namespace internal { namespace core {
 
 bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& output) {
-  output.clear();
   const int column_count = result->column_count();
   if (column_count > 0) {
-    output.reserve(column_count);
+
+    if (size_t(column_count) == output.size()) {
+      for (int i = 0; i < column_count; ++i) {
+        if (!decoder.decode_value(output[i])) return false;
+      }
+      return true;
+    }
+
+    output.clear(); output.reserve(column_count);
     const SharedRefPtr<ResultMetadata>& metadata = result->metadata();
     for (int i = 0; i < column_count; ++i) {
       const ColumnDefinition& def = metadata->get_column_definition(i);

--- a/src/row.hpp
+++ b/src/row.hpp
@@ -51,6 +51,7 @@ private:
 };
 
 bool decode_row(Decoder& decoder, const ResultResponse* result, OutputValueVec& output);
+bool decode_next_row(Decoder& decoder, OutputValueVec& output);
 
 }}} // namespace datastax::internal::core
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -214,6 +214,12 @@ bool Value::update(const Decoder& decoder) {
   if (!decoder_.is_null()) {
     if (data_type_->is_collection()) {
       return decoder_.decode_int32(count_);
+    } else if (data_type->is_tuple()) {
+      const CompositeType& composite_type = static_cast<const CompositeType&>(*data_type);
+      count_ = composite_type.types().size();
+    } else if (data_type->is_user_type()) {
+      const UserType& user_type = static_cast<const UserType&>(*data_type);
+      count_ = user_type.fields().size();
     }
   } else {
     count_ = 0;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -225,6 +225,7 @@ bool Value::update(const Decoder& decoder) {
     count_ = 0;
     is_null_ = true;
   }
+
   return true;
 }
 

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -209,6 +209,17 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
   }
 }
 
+bool Value::update(const Decoder& decoder) {
+  decoder_ = decoder;
+  int32_t count = 0;
+  if (data_type_->is_collection()) {
+    if (decoder_.decode_int32(count)) {
+      count_ = count;
+    } else return false;
+  }
+  return false;
+}
+
 bool Value::as_bool() const {
   assert(!is_null() && value_type() == CASS_VALUE_TYPE_BOOLEAN);
   bool value = false;

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -214,11 +214,11 @@ bool Value::update(const Decoder& decoder) {
   if (!decoder_.is_null()) {
     if (data_type_->is_collection()) {
       return decoder_.decode_int32(count_);
-    } else if (data_type->is_tuple()) {
-      const CompositeType& composite_type = static_cast<const CompositeType&>(*data_type);
+    } else if (data_type_->is_tuple()) {
+      const CompositeType& composite_type = static_cast<const CompositeType&>(*data_type_);
       count_ = composite_type.types().size();
-    } else if (data_type->is_user_type()) {
-      const UserType& user_type = static_cast<const UserType&>(*data_type);
+    } else if (data_type_->is_user_type()) {
+      const UserType& user_type = static_cast<const UserType&>(*data_type_);
       count_ = user_type.fields().size();
     }
   } else {

--- a/src/value.cpp
+++ b/src/value.cpp
@@ -211,13 +211,15 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
 
 bool Value::update(const Decoder& decoder) {
   decoder_ = decoder;
-  int32_t count = 0;
-  if (data_type_->is_collection()) {
-    if (decoder_.decode_int32(count)) {
-      count_ = count;
-    } else return false;
+  if (!decoder_.is_null()) {
+    if (data_type_->is_collection()) {
+      return decoder_.decode_int32(count_);
+    }
+  } else {
+    count_ = 0;
+    is_null_ = true;
   }
-  return false;
+  return true;
 }
 
 bool Value::as_bool() const {

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -139,7 +139,7 @@ public:
 private:
   friend class Decoder;
   bool update(const Decoder& decoder);
- 
+
 private:
   DataType::ConstPtr data_type_;
   int32_t count_;

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -137,6 +137,10 @@ public:
   StringVec as_stringlist() const;
 
 private:
+  friend class Decoder;
+  bool update(const Decoder& decoder);
+ 
+private:
   DataType::ConstPtr data_type_;
   int32_t count_;
   Decoder decoder_;


### PR DESCRIPTION
This is a "better" row values decoding optimisation compared to the first attempt https://github.com/datastax/cpp-driver/pull/508

It skips creating **Value** objects and populating the row vector on every next row decode, instead it simply updates **Value's** **Decoder** instance and **Value** internal state.
So there is no refcounting, no vector cleanup and memory allocations.

**cass::ResultIterator::next()** - 13.28%
<img width="1190" alt="Screenshot 2021-05-11 at 11 11 15" src="https://user-images.githubusercontent.com/2941615/117799046-a5dccd80-b249-11eb-927e-3d9a004a5f97.png">

**cass::ResultIterator::next()** - 4.45%
<img width="1186" alt="Screenshot 2021-05-11 at 11 08 55" src="https://user-images.githubusercontent.com/2941615/117798811-6910d680-b249-11eb-8beb-51f4cdd1aa48.png">

