### PR TITLE
CPP-944: Fix test builds on aarch64

### DIFF
--- a/tests/src/unit/tests/test_decoder.cpp
+++ b/tests/src/unit/tests/test_decoder.cpp
@@ -61,13 +61,13 @@ bool DecoderUnitTest::failure_logged_ = false;
 bool DecoderUnitTest::warning_logged_ = false;
 
 TEST_F(DecoderUnitTest, DecodeByte) {
-  const char input[2] = { -1, 0 };
-  TestDecoder decoder(input, 2);
+  const signed char input[2] = { -1, 0 };
+  TestDecoder decoder((const char*)input, 2);
   uint8_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_byte(value));
-  ASSERT_EQ(&input[1], decoder.buffer());
+  ASSERT_EQ((char*)&input[1], decoder.buffer());
   ASSERT_EQ(1ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<uint8_t>::max(), value);
   ASSERT_TRUE(decoder.decode_byte(value));
@@ -80,14 +80,14 @@ TEST_F(DecoderUnitTest, DecodeByte) {
 }
 
 TEST_F(DecoderUnitTest, AsByte) {
-  const char input[1] = { -1 };
-  TestDecoder decoder(input, 1);
+  const signed char input[1] = { -1 };
+  TestDecoder decoder((const char*)input, 1);
   uint8_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_byte(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(1ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<uint8_t>::max(), value);
   }
@@ -101,14 +101,14 @@ TEST_F(DecoderUnitTest, AsByte) {
 }
 
 TEST_F(DecoderUnitTest, AsBool) {
-  const char input[2] = { 0, 1 };
-  TestDecoder decoder(input, 2);
+  const signed char input[2] = { 0, 1 };
+  TestDecoder decoder((const char*)input, 2);
   bool value = false;
 
   // SUCCESS (false)
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_bool(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(2ul, decoder.remaining());
     ASSERT_FALSE(value);
   }
@@ -120,7 +120,7 @@ TEST_F(DecoderUnitTest, AsBool) {
   // SUCCESS (true)
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_bool(&value));
-    ASSERT_EQ(&input[1], decoder.buffer());
+    ASSERT_EQ((const char*)&input[1], decoder.buffer());
     ASSERT_EQ(1ul, decoder.remaining());
     ASSERT_TRUE(value);
   }
@@ -134,13 +134,13 @@ TEST_F(DecoderUnitTest, AsBool) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInt8) {
-  const char input[2] = { -128, 127 };
-  TestDecoder decoder(input, 2);
+  const signed char input[2] = { -128, 127 };
+  TestDecoder decoder((const char*)input, 2);
   int8_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_int8(value));
-  ASSERT_EQ(&input[1], decoder.buffer());
+  ASSERT_EQ((const char*)&input[1], decoder.buffer());
   ASSERT_EQ(1ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<int8_t>::min(), value);
   ASSERT_TRUE(decoder.decode_int8(value));
@@ -153,14 +153,14 @@ TEST_F(DecoderUnitTest, DecodeInt8) {
 }
 
 TEST_F(DecoderUnitTest, AsInt8) {
-  const char input[1] = { -128 };
-  TestDecoder decoder(input, 1);
+  const signed char input[1] = { -128 };
+  TestDecoder decoder((const char*)input, 1);
   int8_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_int8(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(1ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<int8_t>::min(), value);
   }
@@ -175,13 +175,13 @@ TEST_F(DecoderUnitTest, AsInt8) {
 }
 
 TEST_F(DecoderUnitTest, DecodeUInt16) {
-  const char input[4] = { -1, -1, 0, 0 };
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { -1, -1, 0, 0 };
+  TestDecoder decoder((const char*)input, 4);
   uint16_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_uint16(value));
-  ASSERT_EQ(&input[2], decoder.buffer());
+  ASSERT_EQ((const char*)&input[2], decoder.buffer());
   ASSERT_EQ(2ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<uint16_t>::max(), value);
   ASSERT_TRUE(decoder.decode_uint16(value));
@@ -194,13 +194,13 @@ TEST_F(DecoderUnitTest, DecodeUInt16) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInt16) {
-  const char input[4] = { -128, 0, 127, -1 };
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { -128, 0, 127, -1 };
+  TestDecoder decoder((const char*)input, 4);
   int16_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_int16(value));
-  ASSERT_EQ(&input[2], decoder.buffer());
+  ASSERT_EQ((const char*)&input[2], decoder.buffer());
   ASSERT_EQ(2ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<int16_t>::min(), value);
   ASSERT_TRUE(decoder.decode_int16(value));
@@ -213,14 +213,14 @@ TEST_F(DecoderUnitTest, DecodeInt16) {
 }
 
 TEST_F(DecoderUnitTest, AsInt16) {
-  const char input[2] = { -128, 0 };
-  TestDecoder decoder(input, 2);
+  const signed char input[2] = { -128, 0 };
+  TestDecoder decoder((const char*)input, 2);
   int16_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_int16(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(2ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<int16_t>::min(), value);
   }
@@ -235,13 +235,13 @@ TEST_F(DecoderUnitTest, AsInt16) {
 }
 
 TEST_F(DecoderUnitTest, DecodeUInt32) {
-  const char input[8] = { -1, -1, -1, -1, 0, 0, 0, 0 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { -1, -1, -1, -1, 0, 0, 0, 0 };
+  TestDecoder decoder((const char*)input, 8);
   uint32_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_uint32(value));
-  ASSERT_EQ(&input[4], decoder.buffer());
+  ASSERT_EQ((const char*)&input[4], decoder.buffer());
   ASSERT_EQ(4ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<uint32_t>::max(), value);
   ASSERT_TRUE(decoder.decode_uint32(value));
@@ -254,14 +254,14 @@ TEST_F(DecoderUnitTest, DecodeUInt32) {
 }
 
 TEST_F(DecoderUnitTest, AsUInt32) {
-  const char input[4] = { -1, -1, -1, -1 };
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { -1, -1, -1, -1 };
+  TestDecoder decoder((const char*)input, 4);
   uint32_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_uint32(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(std::numeric_limits<uint32_t>::max(), value);
   }
 
@@ -275,13 +275,13 @@ TEST_F(DecoderUnitTest, AsUInt32) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInt32) {
-  const char input[8] = { -128, 0, 0, 0, 127, -1, -1, -1 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { -128, 0, 0, 0, 127, -1, -1, -1 };
+  TestDecoder decoder((const char*)input, 8);
   int32_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_int32(value));
-  ASSERT_EQ(&input[4], decoder.buffer());
+  ASSERT_EQ((const char*)&input[4], decoder.buffer());
   ASSERT_EQ(4ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<int32_t>::min(), value);
   ASSERT_TRUE(decoder.decode_int32(value));
@@ -294,14 +294,14 @@ TEST_F(DecoderUnitTest, DecodeInt32) {
 }
 
 TEST_F(DecoderUnitTest, AsInt32) {
-  const char input[4] = { -128, 0, 0, 0 };
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { -128, 0, 0, 0 };
+  TestDecoder decoder((const char*)input, 4);
   int32_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_int32(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(4ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<int32_t>::min(), value);
   }
@@ -316,13 +316,13 @@ TEST_F(DecoderUnitTest, AsInt32) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInt64) {
-  const char input[16] = { -128, 0, 0, 0, 0, 0, 0, 0, 127, -1, -1, -1, -1, -1, -1, -1 };
-  TestDecoder decoder(input, 16);
+  const signed char input[16] = { -128, 0, 0, 0, 0, 0, 0, 0, 127, -1, -1, -1, -1, -1, -1, -1 };
+  TestDecoder decoder((const char*)input, 16);
   int64_t value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_int64(value));
-  ASSERT_EQ(&input[8], decoder.buffer());
+  ASSERT_EQ((const char*)&input[8], decoder.buffer());
   ASSERT_EQ(8ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<int64_t>::min(), value);
   ASSERT_TRUE(decoder.decode_int64(value));
@@ -335,14 +335,14 @@ TEST_F(DecoderUnitTest, DecodeInt64) {
 }
 
 TEST_F(DecoderUnitTest, AsInt64) {
-  const char input[8] = { -128, 0, 0, 0, 0, 0, 0, 0 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { -128, 0, 0, 0, 0, 0, 0, 0 };
+  TestDecoder decoder((const char*)input, 8);
   cass_int64_t value = 0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_int64(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(8ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<cass_int64_t>::min(), value);
   }
@@ -357,13 +357,13 @@ TEST_F(DecoderUnitTest, AsInt64) {
 }
 
 TEST_F(DecoderUnitTest, DecodeFloat) {
-  const char input[8] = { 0, -128, 0, 0, 127, 127, -1, -1 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { 0, -128, 0, 0, 127, 127, -1, -1 };
+  TestDecoder decoder((const char*)input, 8);
   float value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_float(value));
-  ASSERT_EQ(&input[4], decoder.buffer());
+  ASSERT_EQ((const char*)&input[4], decoder.buffer());
   ASSERT_EQ(4ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<float>::min(), value);
   ASSERT_TRUE(decoder.decode_float(value));
@@ -376,14 +376,14 @@ TEST_F(DecoderUnitTest, DecodeFloat) {
 }
 
 TEST_F(DecoderUnitTest, AsFloat) {
-  const char input[4] = { 0, -128, 0, 0 };
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { 0, -128, 0, 0 };
+  TestDecoder decoder((const char*)input, 4);
   float value = 0.0f;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_float(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(4ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<float>::min(), value);
   }
@@ -398,13 +398,13 @@ TEST_F(DecoderUnitTest, AsFloat) {
 }
 
 TEST_F(DecoderUnitTest, DecodeDouble) {
-  const char input[16] = { 0, 16, 0, 0, 0, 0, 0, 0, 127, -17, -1, -1, -1, -1, -1, -1 };
-  TestDecoder decoder(input, 16);
+  const signed char input[16] = { 0, 16, 0, 0, 0, 0, 0, 0, 127, -17, -1, -1, -1, -1, -1, -1 };
+  TestDecoder decoder((const char*)input, 16);
   double value = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_double(value));
-  ASSERT_EQ(&input[8], decoder.buffer());
+  ASSERT_EQ((const char*)&input[8], decoder.buffer());
   ASSERT_EQ(8ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<double>::min(), value);
   ASSERT_TRUE(decoder.decode_double(value));
@@ -417,14 +417,14 @@ TEST_F(DecoderUnitTest, DecodeDouble) {
 }
 
 TEST_F(DecoderUnitTest, AsDouble) {
-  const char input[8] = { 0, 16, 0, 0, 0, 0, 0, 0 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { 0, 16, 0, 0, 0, 0, 0, 0 };
+  TestDecoder decoder((const char*)input, 8);
   double value = 0.0;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_double(&value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(8ul, decoder.remaining());
     ASSERT_EQ(std::numeric_limits<double>::min(), value);
   }
@@ -439,15 +439,15 @@ TEST_F(DecoderUnitTest, AsDouble) {
 }
 
 TEST_F(DecoderUnitTest, DecodeString) {
-  const char input[17] = { 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 17);
+  const signed char input[17] = { 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 17);
   const char* value = NULL;
   size_t value_size = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_string(&value, value_size));
-  ASSERT_EQ(&input[10], decoder.buffer());
+  ASSERT_EQ((const char*)&input[10], decoder.buffer());
   ASSERT_EQ(7ul, decoder.remaining());
   ASSERT_EQ(8ul, value_size);
   ASSERT_STREQ("DataStax", std::string(value, value_size).c_str());
@@ -462,14 +462,14 @@ TEST_F(DecoderUnitTest, DecodeString) {
 }
 
 TEST_F(DecoderUnitTest, DecodeStringRef) {
-  const char input[17] = { 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 17);
+  const signed char input[17] = { 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 17);
   StringRef value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_string(&value));
-  ASSERT_EQ(&input[10], decoder.buffer());
+  ASSERT_EQ((const char*)&input[10], decoder.buffer());
   ASSERT_EQ(7ul, decoder.remaining());
   ASSERT_EQ(8ul, value.size());
   ASSERT_STREQ("DataStax", std::string(value.data(), value.size()).c_str());
@@ -484,15 +484,15 @@ TEST_F(DecoderUnitTest, DecodeStringRef) {
 }
 
 TEST_F(DecoderUnitTest, DecodeLongString) {
-  const char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 21);
+  const signed char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 21);
   const char* value = NULL;
   size_t value_size = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_long_string(&value, value_size));
-  ASSERT_EQ(&input[12], decoder.buffer());
+  ASSERT_EQ((const char*)&input[12], decoder.buffer());
   ASSERT_EQ(9ul, decoder.remaining());
   ASSERT_EQ(8ul, value_size);
   ASSERT_STREQ("DataStax", std::string(value, value_size).c_str());
@@ -507,15 +507,15 @@ TEST_F(DecoderUnitTest, DecodeLongString) {
 }
 
 TEST_F(DecoderUnitTest, DecodeBytes) {
-  const char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 21);
+  const signed char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 21);
   const char* value = NULL;
   size_t value_size = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_bytes(&value, value_size));
-  ASSERT_EQ(&input[12], decoder.buffer());
+  ASSERT_EQ((const char*)&input[12], decoder.buffer());
   ASSERT_EQ(9ul, decoder.remaining());
   ASSERT_EQ(8ul, value_size);
   for (int i = 0; i < 8; ++i) {
@@ -525,7 +525,7 @@ TEST_F(DecoderUnitTest, DecodeBytes) {
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(5ul, value_size);
   for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(input[i + 16], value[i]);
+    ASSERT_EQ((char)input[i + 16], value[i]);
   }
 
   // FAIL
@@ -534,24 +534,24 @@ TEST_F(DecoderUnitTest, DecodeBytes) {
 }
 
 TEST_F(DecoderUnitTest, DecodeBytesRef) {
-  const char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 21);
+  const signed char input[21] = { 0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 21);
   StringRef value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_bytes(&value));
-  ASSERT_EQ(&input[12], decoder.buffer());
+  ASSERT_EQ((const char*)&input[12], decoder.buffer());
   ASSERT_EQ(9ul, decoder.remaining());
   ASSERT_EQ(8ul, value.size());
   for (int i = 0; i < 8; ++i) {
-    ASSERT_EQ(input[i + 4], value.data()[i]);
+    ASSERT_EQ((char)input[i + 4], value.data()[i]);
   }
   ASSERT_TRUE(decoder.decode_bytes(&value));
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(5ul, value.size());
   for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(input[i + 16], value.data()[i]);
+    ASSERT_EQ((char)input[i + 16], value.data()[i]);
   }
 
   // FAIL
@@ -560,16 +560,15 @@ TEST_F(DecoderUnitTest, DecodeBytesRef) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInetAddress) {
-  const char input[30] = {
-    4,  127, 0, 0, 1, 0, 0, 35, 82, // 127.0.0.1:9042
-    16, 0,   0, 0, 0, 0, 0, 0,  0,  0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 35, 82
-  }; // [::1]:9042
-  TestDecoder decoder(input, 30);
+  const signed char input[30] = { 4,  127, 0, 0, 1, 0, 0, 35, 82, // 127.0.0.1:9042
+                                  16, 0,   0, 0, 0, 0, 0, 0,  0,  0, 0,
+                                  0,  0,   0, 0, 0, 1, 0, 0,  35, 82 }; // [::1]:9042
+  TestDecoder decoder((const char*)input, 30);
   Address value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_inet(&value));
-  ASSERT_EQ(&input[9], decoder.buffer());
+  ASSERT_EQ((const char*)&input[9], decoder.buffer());
   ASSERT_EQ(21ul, decoder.remaining());
   ASSERT_STREQ("127.0.0.1:9042", value.to_string(true).c_str());
   ASSERT_TRUE(decoder.decode_inet(&value));
@@ -582,25 +581,25 @@ TEST_F(DecoderUnitTest, DecodeInetAddress) {
 }
 
 TEST_F(DecoderUnitTest, DecodeInetStruct) {
-  const char input[22] = { 4,  127, 0, 0, 1,                                       // 127.0.0.1
-                           16, 0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }; // [::1]
-  TestDecoder decoder(input, 22);
+  const signed char input[22] = { 4,  127, 0, 0, 1, // 127.0.0.1
+                                  16, 0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }; // [::1]
+  TestDecoder decoder((const char*)input, 22);
   CassInet value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_inet(&value));
-  ASSERT_EQ(&input[5], decoder.buffer());
+  ASSERT_EQ((const char*)&input[5], decoder.buffer());
   ASSERT_EQ(17ul, decoder.remaining());
   for (int i = 0; i < value.address_length; ++i) {
     uint8_t byte = 0;
-    decode_byte(&input[i + 1], byte);
+    decode_byte((const char*)&input[i + 1], byte);
     ASSERT_EQ(byte, value.address[i]);
   }
   ASSERT_TRUE(decoder.decode_inet(&value));
   ASSERT_EQ(0ul, decoder.remaining());
   for (int i = 0; i < value.address_length; ++i) {
     uint8_t byte = 0;
-    decode_byte(&input[i + 6], byte);
+    decode_byte((const char*)&input[i + 6], byte);
     ASSERT_EQ(byte, value.address[i]);
   }
 
@@ -610,18 +609,18 @@ TEST_F(DecoderUnitTest, DecodeInetStruct) {
 }
 
 TEST_F(DecoderUnitTest, AsInetIPv4) {
-  const char input[4] = { 127, 0, 0, 1 }; // 127.0.0.1
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { 127, 0, 0, 1 }; // 127.0.0.1
+  TestDecoder decoder((const char*)input, 4);
   CassInet value;
 
   // SUCCESS (IPv4)
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_inet(4, &value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(4ul, decoder.remaining());
     for (int j = 0; j < value.address_length; ++j) {
       uint8_t byte = 0;
-      decode_byte(&input[j], byte);
+      decode_byte((const char*)&input[j], byte);
       ASSERT_EQ(byte, value.address[j]);
     }
   }
@@ -629,18 +628,18 @@ TEST_F(DecoderUnitTest, AsInetIPv4) {
 }
 
 TEST_F(DecoderUnitTest, AsInetIPv6) {
-  const char input[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }; // [::1]
-  TestDecoder decoder(input, 16);
+  const signed char input[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }; // [::1]
+  TestDecoder decoder((const char*)input, 16);
   CassInet value;
 
   // SUCCESS (IPv6)
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_inet(16, &value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(16ul, decoder.remaining());
     for (int j = 0; j < value.address_length; ++j) {
       uint8_t byte = 0;
-      decode_byte(&input[j], byte);
+      decode_byte((const char*)&input[j], byte);
       ASSERT_EQ(byte, value.address[j]);
     }
   }
@@ -648,16 +647,16 @@ TEST_F(DecoderUnitTest, AsInetIPv6) {
 }
 
 TEST_F(DecoderUnitTest, DecodeStringMap) {
-  const char input[38] = { 0, 2, 0,   7,  99,  111, 109, 112, 97,  110, 121, // key = company
-                           0, 8, 68,  97, 116, 97,  83,  116, 97,  120,      // value = DataStax
-                           0, 8, 108, 97, 110, 103, 117, 97,  103, 101,      // key = language
-                           0, 5, 67,  47, 67,  43,  43 };                    // value = C/C++
-  TestDecoder decoder(input, 38);
+  const signed char input[38] = { 0, 2, 0,   7,  99,  111, 109, 112, 97,  110, 121, // key = company
+                                  0, 8, 68,  97, 116, 97,  83,  116, 97,  120, // value = DataStax
+                                  0, 8, 108, 97, 110, 103, 117, 97,  103, 101, // key = language
+                                  0, 5, 67,  47, 67,  43,  43 };               // value = C/C++
+  TestDecoder decoder((const char*)input, 38);
   Map<String, String> value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_string_map(value));
-  ASSERT_EQ(&input[38], decoder.buffer());
+  ASSERT_EQ((const char*)&input[38], decoder.buffer());
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(2ul, value.size());
   ASSERT_STREQ("DataStax", value["company"].c_str());
@@ -669,14 +668,14 @@ TEST_F(DecoderUnitTest, DecodeStringMap) {
 }
 
 TEST_F(DecoderUnitTest, DecodeStringlistVector) {
-  const char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 5, 67, 47, 67, 43, 43 };                      // C/C++
-  TestDecoder decoder(input, 19);
+  const signed char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 5, 67, 47, 67, 43, 43 };                      // C/C++
+  TestDecoder decoder((const char*)input, 19);
   Vector<String> value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_stringlist(value));
-  ASSERT_EQ(&input[19], decoder.buffer());
+  ASSERT_EQ((const char*)&input[19], decoder.buffer());
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(2ul, value.size());
   ASSERT_STREQ("DataStax", value[0].c_str());
@@ -688,14 +687,14 @@ TEST_F(DecoderUnitTest, DecodeStringlistVector) {
 }
 
 TEST_F(DecoderUnitTest, DecodeStringlistStringRefVec) {
-  const char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 5, 67, 47, 67, 43, 43 };                      // C/C++
-  TestDecoder decoder(input, 19);
+  const signed char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 5, 67, 47, 67, 43, 43 };                      // C/C++
+  TestDecoder decoder((const char*)input, 19);
   StringRefVec value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_stringlist(value));
-  ASSERT_EQ(&input[19], decoder.buffer());
+  ASSERT_EQ((const char*)&input[19], decoder.buffer());
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(2ul, value.size());
   ASSERT_STREQ("DataStax", std::string(value[0].data(), value[0].size()).c_str());
@@ -707,15 +706,15 @@ TEST_F(DecoderUnitTest, DecodeStringlistStringRefVec) {
 }
 
 TEST_F(DecoderUnitTest, AsStringlist) {
-  const char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 5, 67, 47, 67, 43, 43 };                      // C/C++
-  TestDecoder decoder(input, 19);
+  const signed char input[19] = { 0, 2, 0,  8,  68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 5, 67, 47, 67, 43, 43 };                      // C/C++
+  TestDecoder decoder((const char*)input, 19);
   StringRefVec value;
 
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_stringlist(value));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(19ul, decoder.remaining());
     ASSERT_EQ(2ul, value.size());
     ASSERT_STREQ("DataStax", std::string(value[0].data(), value[0].size()).c_str());
@@ -731,20 +730,20 @@ TEST_F(DecoderUnitTest, AsStringlist) {
 }
 
 TEST_F(DecoderUnitTest, DecodeStringMultiMap) {
-  const char input[58] = { 0, 1, 0,  7,   100, 114, 105, 118, 101, 114, 115, // key = drivers
-                           0, 7, 0,  5,   67,  47,  67,  43,  43,            // C/C++
-                           0, 2, 67, 35,                                     // C#
-                           0, 4, 74, 97,  118, 97,                           // Java
-                           0, 7, 78, 111, 100, 101, 46,  106, 115,           // Node.js
-                           0, 3, 80, 72,  80,                                // PHP
-                           0, 6, 80, 121, 116, 104, 111, 110,                // Python
-                           0, 4, 82, 117, 98,  121 };                        // Ruby
-  TestDecoder decoder(input, 58);
+  const signed char input[58] = { 0, 1, 0,  7,   100, 114, 105, 118, 101, 114, 115, // key = drivers
+                                  0, 7, 0,  5,   67,  47,  67,  43,  43,            // C/C++
+                                  0, 2, 67, 35,                                     // C#
+                                  0, 4, 74, 97,  118, 97,                           // Java
+                                  0, 7, 78, 111, 100, 101, 46,  106, 115,           // Node.js
+                                  0, 3, 80, 72,  80,                                // PHP
+                                  0, 6, 80, 121, 116, 104, 111, 110,                // Python
+                                  0, 4, 82, 117, 98,  121 };                        // Ruby
+  TestDecoder decoder((const char*)input, 58);
   StringMultimap value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_string_multimap(value));
-  ASSERT_EQ(&input[58], decoder.buffer());
+  ASSERT_EQ((const char*)&input[58], decoder.buffer());
   ASSERT_EQ(0ul, decoder.remaining());
   ASSERT_EQ(1ul, value.size());
   Vector<String> values = value["drivers"];
@@ -763,16 +762,18 @@ TEST_F(DecoderUnitTest, DecodeStringMultiMap) {
 }
 
 TEST_F(DecoderUnitTest, DecodeOption) {
-  const char input[14] = { 0, 1,                                            // ASCII
-                           0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120 }; // Custom = DataStax
-  TestDecoder decoder(input, 14);
+  const signed char input[14] = {
+    0, 1, // ASCII
+    0, 0, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120
+  }; // Custom = DataStax
+  TestDecoder decoder((const char*)input, 14);
   uint16_t type;
   const char* class_name = NULL;
   size_t class_name_size = 0;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_option(type, &class_name, class_name_size));
-  ASSERT_EQ(&input[2], decoder.buffer());
+  ASSERT_EQ((const char*)&input[2], decoder.buffer());
   ASSERT_EQ(12ul, decoder.remaining());
   ASSERT_EQ(CASS_VALUE_TYPE_ASCII, type);
   ASSERT_TRUE(decoder.decode_option(type, &class_name, class_name_size));
@@ -787,14 +788,14 @@ TEST_F(DecoderUnitTest, DecodeOption) {
 }
 
 TEST_F(DecoderUnitTest, DecodeUuid) {
-  const char input[32] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
-  TestDecoder decoder(input, 32);
+  const signed char input[32] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                                  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
+  TestDecoder decoder((const char*)input, 32);
   CassUuid value;
 
   // SUCCESS
   ASSERT_TRUE(decoder.decode_uuid(&value));
-  ASSERT_EQ(&input[16], decoder.buffer());
+  ASSERT_EQ((const char*)&input[16], decoder.buffer());
   ASSERT_EQ(16ul, decoder.remaining());
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(), value.clock_seq_and_node);
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(), value.time_and_version);
@@ -809,8 +810,8 @@ TEST_F(DecoderUnitTest, DecodeUuid) {
 }
 
 TEST_F(DecoderUnitTest, AsDecimal) {
-  const char input[8] = { 0, 0, 0, 4, 0, 1, 2, 3 };
-  TestDecoder decoder(input, 8);
+  const signed char input[8] = { 0, 0, 0, 4, 0, 1, 2, 3 };
+  TestDecoder decoder((const char*)input, 8);
   const uint8_t* value = NULL;
   size_t value_size = 0;
   int32_t value_scale = 0;
@@ -818,11 +819,11 @@ TEST_F(DecoderUnitTest, AsDecimal) {
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_decimal(&value, &value_size, &value_scale));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(8ul, decoder.remaining());
     for (size_t j = 0; j < value_size; ++j) {
       uint8_t byte = 0;
-      decode_byte(&input[j + sizeof(int32_t)], byte);
+      decode_byte((const char*)&input[j + sizeof(int32_t)], byte);
       ASSERT_EQ(byte, value[j]);
     }
   }
@@ -839,8 +840,8 @@ TEST_F(DecoderUnitTest, AsDecimal) {
 }
 
 TEST_F(DecoderUnitTest, AsDuration) {
-  const char input[4] = { 2, 4, 6, -127 }; // 1, 2, 3 (zig zag encoding)
-  TestDecoder decoder(input, 4);
+  const signed char input[4] = { 2, 4, 6, -127 }; // 1, 2, 3 (zig zag encoding)
+  TestDecoder decoder((const char*)input, 4);
   int32_t months = 0;
   int32_t days = 0;
   int64_t nanos = 0;
@@ -848,7 +849,7 @@ TEST_F(DecoderUnitTest, AsDuration) {
   // SUCCESS
   for (int i = 0; i < 10; ++i) {
     ASSERT_TRUE(decoder.as_duration(&months, &days, &nanos));
-    ASSERT_EQ(&input[0], decoder.buffer());
+    ASSERT_EQ((const char*)&input[0], decoder.buffer());
     ASSERT_EQ(4ul, decoder.remaining());
     ASSERT_EQ(1, months);
     ASSERT_EQ(2, days);
@@ -867,9 +868,9 @@ TEST_F(DecoderUnitTest, AsDuration) {
 }
 
 TEST_F(DecoderUnitTest, DecodeCustomPayload) {
-  const char input[21] = { 0, 1, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
-                           0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
-  TestDecoder decoder(input, 21);
+  const signed char input[21] = { 0, 1, 0, 8, 68, 97, 116, 97, 83, 116, 97, 120, // DataStax
+                                  0, 0, 0, 5, 67, 47, 67,  43, 43 };             // C/C++
+  TestDecoder decoder((const char*)input, 21);
   CustomPayloadVec value;
 
   // SUCCESS
@@ -880,7 +881,7 @@ TEST_F(DecoderUnitTest, DecodeCustomPayload) {
   ASSERT_STREQ("DataStax", std::string(value[0].name.data(), value[0].name.size()).c_str());
   ASSERT_EQ(5ul, value[0].value.size());
   for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(input[i + 16], value[0].value.data()[i]);
+    ASSERT_EQ((char)input[i + 16], value[0].value.data()[i]);
   }
 
   // FAIL
@@ -889,8 +890,8 @@ TEST_F(DecoderUnitTest, DecodeCustomPayload) {
 }
 
 TEST_F(DecoderUnitTest, DecodeFailures) {
-  const char input[4] = { 0, 0, 0, 42 };
-  TestDecoder decoder(input, 4, 1);
+  const signed char input[4] = { 0, 0, 0, 42 };
+  TestDecoder decoder((const char*)input, 4, 1);
   FailureVec value;
   int32_t value_size = 0;
 
@@ -906,10 +907,11 @@ TEST_F(DecoderUnitTest, DecodeFailures) {
 }
 
 TEST_F(DecoderUnitTest, DecodeFailuresWithVector) {
-  const char input[30] = { 0, 0, 0,  2, 4, 127, 0, 0, 1,                               // 127.0.0.1
-                           0, 1, 16, 0, 0, 0,   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // [::1] [02]
-                           0, 2 };
-  TestDecoder decoder(input, 30, 5);
+  const signed char input[30] = { 0, 0, 0,  2, 4, 127, 0, 0, 1, // 127.0.0.1
+                                  0, 1, 16, 0, 0, 0,   0, 0, 0, 0,
+                                  0, 0, 0,  0, 0, 0,   0, 0, 1, // [::1] [02]
+                                  0, 2 };
+  TestDecoder decoder((const char*)input, 30, 5);
   FailureVec value;
   int32_t value_size = 0;
 
@@ -920,13 +922,13 @@ TEST_F(DecoderUnitTest, DecodeFailuresWithVector) {
   ASSERT_EQ(2, value_size);
   for (int i = 0; i < value[0].endpoint.address_length; ++i) {
     uint8_t byte;
-    decode_byte(&input[i + 5], byte);
+    decode_byte((const char*)&input[i + 5], byte);
     ASSERT_EQ(byte, value[0].endpoint.address[i]);
   }
   ASSERT_EQ(1ul, value[0].failurecode);
   for (int i = 0; i < value[1].endpoint.address_length; ++i) {
     uint8_t byte;
-    decode_byte(&input[i + 12], byte);
+    decode_byte((const char*)&input[i + 12], byte);
     ASSERT_EQ(byte, value[1].endpoint.address[i]);
   }
   ASSERT_EQ(2ul, value[1].failurecode);
@@ -937,16 +939,16 @@ TEST_F(DecoderUnitTest, DecodeFailuresWithVector) {
 }
 
 TEST_F(DecoderUnitTest, DecodeWriteType) {
-  const char input[67] = { 0,  6,  83, 73, 77, 80, 76, 69, // SIMPLE
-                           0,  5,  66, 65, 84, 67, 72,     // BATCH
-                           0,  14, 85, 78, 76, 79, 71, 71, 69, 68, 95,
-                           66, 65, 84, 67, 72,                         // UNLOGGED_BATCH
-                           0,  7,  67, 79, 85, 78, 84, 69, 82,         // COUNTER
-                           0,  9,  66, 65, 84, 67, 72, 95, 76, 79, 71, // BATCH_LOG
-                           0,  3,  67, 65, 83,                         // CAS
-                           0,  4,  86, 73, 69, 87,                     // VIEW
-                           0,  3,  67, 68, 67 };                       // CDC
-  TestDecoder decoder(input, 67);
+  const signed char input[67] = { 0,  6,  83, 73, 77, 80, 76, 69, // SIMPLE
+                                  0,  5,  66, 65, 84, 67, 72,     // BATCH
+                                  0,  14, 85, 78, 76, 79, 71, 71, 69, 68, 95,
+                                  66, 65, 84, 67, 72,                         // UNLOGGED_BATCH
+                                  0,  7,  67, 79, 85, 78, 84, 69, 82,         // COUNTER
+                                  0,  9,  66, 65, 84, 67, 72, 95, 76, 79, 71, // BATCH_LOG
+                                  0,  3,  67, 65, 83,                         // CAS
+                                  0,  4,  86, 73, 69, 87,                     // VIEW
+                                  0,  3,  67, 68, 67 };                       // CDC
+  TestDecoder decoder((const char*)input, 67);
   CassWriteType value;
 
   // SUCCESS
@@ -982,11 +984,11 @@ TEST_F(DecoderUnitTest, DecodeWriteType) {
 }
 
 TEST_F(DecoderUnitTest, DecodeWarnings) {
-  const char input[38] = { 0,   2,   0,   16,  87,  97,  114, 110, 105, 110,
-                           103, 32,  78,  117, 109, 98,  101, 114, 32,  49, // Warning Number 1
-                           0,   16,  87,  97,  114, 110, 105, 110, 103, 32,
-                           78,  117, 109, 98,  101, 114, 32,  50 }; // Warning Number 2
-  TestDecoder decoder(input, 38);
+  const signed char input[38] = { 0,   2,   0,   16,  87,  97,  114, 110, 105, 110, 103,
+                                  32,  78,  117, 109, 98,  101, 114, 32,  49, // Warning Number 1
+                                  0,   16,  87,  97,  114, 110, 105, 110, 103, 32,  78,
+                                  117, 109, 98,  101, 114, 32,  50 }; // Warning Number 2
+  TestDecoder decoder((const char*)input, 38);
   WarningVec value;
 
   // SUCCESS

--- a/tests/src/unit/tests/test_serialization.cpp
+++ b/tests/src/unit/tests/test_serialization.cpp
@@ -24,112 +24,112 @@ using namespace datastax::internal;
 TEST(SerializationTest, DecodeZigZag) { ASSERT_EQ(1LL << 63, decode_zig_zag((long)-1)); }
 
 TEST(SerializationTest, DecodeByte) {
-  const char input[2] = { -1, 0 };
+  const signed char input[2] = { -1, 0 };
   uint8_t value = 0;
 
-  const char* pos = decode_byte(&input[0], value);
-  ASSERT_EQ(&input[1], pos);
+  const char* pos = decode_byte((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[1], pos);
   ASSERT_EQ(std::numeric_limits<uint8_t>::max(), value);
   pos = decode_byte(pos, value);
   ASSERT_EQ(std::numeric_limits<uint8_t>::min(), value);
 }
 
 TEST(SerializationTest, DecodeInt8) {
-  const char input[2] = { -128, 127 };
+  const signed char input[2] = { -128, 127 };
   int8_t value = 0;
 
-  const char* pos = decode_int8(&input[0], value);
-  ASSERT_EQ(&input[1], pos);
+  const char* pos = decode_int8((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[1], pos);
   ASSERT_EQ(std::numeric_limits<int8_t>::min(), value);
   pos = decode_int8(pos, value);
   ASSERT_EQ(std::numeric_limits<int8_t>::max(), value);
 }
 
 TEST(SerializationTest, DecodeUInt16) {
-  const char input[4] = { -1, -1, 0, 0 };
+  const signed char input[4] = { -1, -1, 0, 0 };
   uint16_t value = 0;
 
-  const char* pos = decode_uint16(&input[0], value);
-  ASSERT_EQ(&input[2], pos);
+  const char* pos = decode_uint16((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[2], pos);
   ASSERT_EQ(std::numeric_limits<uint16_t>::max(), value);
   pos = decode_uint16(pos, value);
   ASSERT_EQ(std::numeric_limits<uint16_t>::min(), value);
 }
 
 TEST(SerializationTest, DecodeInt16) {
-  const char input[4] = { -128, 0, 127, -1 };
+  const signed char input[4] = { -128, 0, 127, -1 };
   int16_t value = 0;
 
   // SUCCESS
-  const char* pos = decode_int16(&input[0], value);
-  ASSERT_EQ(&input[2], pos);
+  const char* pos = decode_int16((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[2], pos);
   ASSERT_EQ(std::numeric_limits<int16_t>::min(), value);
   pos = decode_int16(pos, value);
   ASSERT_EQ(std::numeric_limits<int16_t>::max(), value);
 }
 
 TEST(SerializationTest, DecodeUInt32) {
-  const char input[8] = { -1, -1, -1, -1, 0, 0, 0, 0 };
+  const signed char input[8] = { -1, -1, -1, -1, 0, 0, 0, 0 };
   uint32_t value = 0;
 
-  const char* pos = decode_uint32(&input[0], value);
-  ASSERT_EQ(&input[4], pos);
+  const char* pos = decode_uint32((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[4], pos);
   ASSERT_EQ(std::numeric_limits<uint32_t>::max(), value);
   pos = decode_uint32(pos, value);
   ASSERT_EQ(std::numeric_limits<uint32_t>::min(), value);
 }
 
 TEST(SerializationTest, DecodeInt32) {
-  const char input[8] = { -128, 0, 0, 0, 127, -1, -1, -1 };
+  const signed char input[8] = { -128, 0, 0, 0, 127, -1, -1, -1 };
   int32_t value = 0;
 
-  const char* pos = decode_int32(&input[0], value);
-  ASSERT_EQ(&input[4], pos);
+  const char* pos = decode_int32((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[4], pos);
   ASSERT_EQ(std::numeric_limits<int32_t>::min(), value);
   pos = decode_int32(pos, value);
   ASSERT_EQ(std::numeric_limits<int32_t>::max(), value);
 }
 
 TEST(SerializationTest, DecodeInt64) {
-  const char input[16] = { -128, 0, 0, 0, 0, 0, 0, 0, 127, -1, -1, -1, -1, -1, -1, -1 };
+  const signed char input[16] = { -128, 0, 0, 0, 0, 0, 0, 0, 127, -1, -1, -1, -1, -1, -1, -1 };
   int64_t value = 0;
 
-  const char* pos = decode_int64(&input[0], value);
-  ASSERT_EQ(&input[8], pos);
+  const char* pos = decode_int64((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[8], pos);
   ASSERT_EQ(std::numeric_limits<int64_t>::min(), value);
   pos = decode_int64(pos, value);
   ASSERT_EQ(std::numeric_limits<int64_t>::max(), value);
 }
 
 TEST(SerializationTest, DecodeFloat) {
-  const char input[8] = { 0, -128, 0, 0, 127, 127, -1, -1 };
+  const signed char input[8] = { 0, -128, 0, 0, 127, 127, -1, -1 };
   float value = 0;
 
-  const char* pos = decode_float(&input[0], value);
-  ASSERT_EQ(&input[4], pos);
+  const char* pos = decode_float((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[4], pos);
   ASSERT_EQ(std::numeric_limits<float>::min(), value);
   pos = decode_float(pos, value);
   ASSERT_EQ(std::numeric_limits<float>::max(), value);
 }
 
 TEST(SerializationTest, DecodeDouble) {
-  const char input[16] = { 0, 16, 0, 0, 0, 0, 0, 0, 127, -17, -1, -1, -1, -1, -1, -1 };
+  const signed char input[16] = { 0, 16, 0, 0, 0, 0, 0, 0, 127, -17, -1, -1, -1, -1, -1, -1 };
   double value = 0;
 
-  const char* pos = decode_double(&input[0], value);
-  ASSERT_EQ(&input[8], pos);
+  const char* pos = decode_double((const char*)&input[0], value);
+  ASSERT_EQ((const char*)&input[8], pos);
   ASSERT_EQ(std::numeric_limits<double>::min(), value);
   pos = decode_double(pos, value);
   ASSERT_EQ(std::numeric_limits<double>::max(), value);
 }
 
 TEST(SerializationTest, DecodeUuid) {
-  const char input[32] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-                           0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
+  const signed char input[32] = { -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+                                  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 };
   CassUuid value;
 
-  const char* pos = decode_uuid(&input[0], &value);
-  ASSERT_EQ(&input[16], pos);
+  const char* pos = decode_uuid((const char*)&input[0], &value);
+  ASSERT_EQ((const char*)&input[16], pos);
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(), value.clock_seq_and_node);
   ASSERT_EQ(std::numeric_limits<uint64_t>::max(), value.time_and_version);
   pos = decode_uuid(pos, &value);

--- a/tests/src/unit/tests/test_value.cpp
+++ b/tests/src/unit/tests/test_value.cpp
@@ -112,11 +112,11 @@ TEST(ValueUnitTest, BadDecimal) {
 }
 
 TEST(ValueUnitTest, NullElementInCollectionList) {
-  const char input[12] = {
+  const signed char input[12] = {
     -1, -1, -1, -1,            // Element 1 is NULL
     0,  0,  0,  4,  0, 0, 0, 2 // Size (int32_t) and contents of element 2
   };
-  Decoder decoder(input, 12);
+  Decoder decoder((const char*)input, 12);
   DataType::ConstPtr element_data_type(new DataType(CASS_VALUE_TYPE_INT));
   CollectionType::ConstPtr data_type = CollectionType::list(element_data_type, false);
   Value value(data_type, 2, decoder);
@@ -134,13 +134,13 @@ TEST(ValueUnitTest, NullElementInCollectionList) {
 }
 
 TEST(ValueUnitTest, NullElementInCollectionMap) {
-  const char input[21] = {
+  const signed char input[21] = {
     -1, -1, -1, -1,               // Key 1 is NULL
     0,  0,  0,  4,  0,   0, 0, 2, // Size (int32_t) and contents of value 1
     0,  0,  0,  1,  'a',          // Key 2 is a
     -1, -1, -1, -1                // Value 2 is NULL
   };
-  Decoder decoder(input, 21);
+  Decoder decoder((const char*)input, 21);
   DataType::ConstPtr key_data_type(new DataType(CASS_VALUE_TYPE_TEXT));
   DataType::ConstPtr value_data_type(new DataType(CASS_VALUE_TYPE_INT));
   CollectionType::ConstPtr data_type = CollectionType::map(key_data_type, value_data_type, false);
@@ -168,11 +168,11 @@ TEST(ValueUnitTest, NullElementInCollectionMap) {
 }
 
 TEST(ValueUnitTest, NullElementInCollectionSet) {
-  const char input[12] = {
+  const signed char input[12] = {
     0,  0,  0,  4,  0, 0, 0, 2, // Size (int32_t) and contents of element 1
     -1, -1, -1, -1,             // Element 2 is NULL
   };
-  Decoder decoder(input, 12);
+  Decoder decoder((const char*)input, 12);
   DataType::ConstPtr element_data_type(new DataType(CASS_VALUE_TYPE_INT));
   CollectionType::ConstPtr data_type = CollectionType::set(element_data_type, false);
   Value value(data_type, 2, decoder);


### PR DESCRIPTION
The signed-ness of 'char' varies by platform. Fix tests that are constructing binary input data as 'char' arrays with negative literals by switching them over to 'signed char' arrays.

https://datastax-oss.atlassian.net/browse/CPP-944