### PR TITLE
Fix SNI events

### DIFF
--- a/src/address_factory.cpp
+++ b/src/address_factory.cpp
@@ -87,11 +87,11 @@ bool SniAddressFactory::create(const Row* peers_row, const Host::Ptr& connected_
 
 bool SniAddressFactory::is_peer(const Row* peers_row, const Host::Ptr& connected_host,
                                 const Address& expected) {
-  const Value* peer_value = peers_row->get_by_name("peer");
-  Address peer_address;
-  if (!peer_value || !peer_value->decoder().as_inet(
-                         peer_value->size(), connected_host->address().port(), &peer_address)) {
+  const Value* value = peers_row->get_by_name("rpc_address");
+  Address rpc_address;
+  if (!value || !value->decoder().as_inet(
+        value->size(), connected_host->address().port(), &rpc_address)) {
     return false;
   }
-  return peer_address.equals(expected, false);
+  return rpc_address == expected;
 }

--- a/src/address_factory.cpp
+++ b/src/address_factory.cpp
@@ -89,8 +89,8 @@ bool SniAddressFactory::is_peer(const Row* peers_row, const Host::Ptr& connected
                                 const Address& expected) {
   const Value* value = peers_row->get_by_name("rpc_address");
   Address rpc_address;
-  if (!value || !value->decoder().as_inet(
-        value->size(), connected_host->address().port(), &rpc_address)) {
+  if (!value ||
+      !value->decoder().as_inet(value->size(), connected_host->address().port(), &rpc_address)) {
     return false;
   }
   return rpc_address == expected;

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -169,7 +169,17 @@ LockedHostMap::LockedHostMap(const HostMap& hosts)
 LockedHostMap::~LockedHostMap() { uv_mutex_destroy(&mutex_); }
 
 LockedHostMap::const_iterator LockedHostMap::find(const Address& address) const {
-  return hosts_.find(address);
+  HostMap::const_iterator it = hosts_.find(address);
+  if (it == hosts_.end()) {
+    // If this is from an event (not SNI) and we're using SNI addresses then fallback to using the
+    // "rpc_address" to compare.
+    for (HostMap::const_iterator i = hosts_.begin(), end = hosts_.end(); i != end; ++i) {
+      if (i->second->rpc_address().equals(address, false)) {
+        return i;
+      }
+    }
+  }
+  return it;
 }
 
 Host::Ptr LockedHostMap::get(const Address& address) const {
@@ -632,7 +642,7 @@ void Cluster::notify_host_remove(const Address& address) {
     notify_or_record(ClusterEvent(ClusterEvent::HOST_DOWN, host));
   }
 
-  hosts_.erase(address);
+  hosts_.erase(it->first);
   for (LoadBalancingPolicy::Vec::const_iterator it = load_balancing_policies_.begin(),
                                                 end = load_balancing_policies_.end();
        it != end; ++it) {

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -174,7 +174,7 @@ LockedHostMap::const_iterator LockedHostMap::find(const Address& address) const 
     // If this is from an event (not SNI) and we're using SNI addresses then fallback to using the
     // "rpc_address" to compare.
     for (HostMap::const_iterator i = hosts_.begin(), end = hosts_.end(); i != end; ++i) {
-      if (i->second->rpc_address().equals(address, false)) {
+      if (i->second->rpc_address() == address) {
         return i;
       }
     }

--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -307,7 +307,7 @@ static NopControlConnectionListener nop_listener__;
 ControlConnectionSettings::ControlConnectionSettings()
     : use_schema(CASS_DEFAULT_USE_SCHEMA)
     , use_token_aware_routing(CASS_DEFAULT_USE_TOKEN_AWARE_ROUTING)
-    , address_factory(new DefaultAddressFactory()) {}
+    , address_factory(new AddressFactory()) {}
 
 ControlConnectionSettings::ControlConnectionSettings(const Config& config)
     : connection_settings(config)
@@ -395,12 +395,10 @@ void ControlConnection::handle_refresh_node(RefreshNodeCallback* callback) {
   const Row* row = NULL;
   ResultIterator rows(callback->result().get());
 
-  while (rows.next() && !found_host) {
+  while (!found_host && rows.next()) {
     row = rows.row();
     if (callback->is_all_peers) {
-      Address address;
-      bool is_valid_address = settings_.address_factory->create(row, connection_->host(), &address);
-      if (is_valid_address && callback->address == address) {
+      if (settings_.address_factory->is_peer(row, connection_->host(), callback->address)) {
         found_host = true;
       }
     } else {

--- a/src/control_connection.cpp
+++ b/src/control_connection.cpp
@@ -395,15 +395,16 @@ void ControlConnection::handle_refresh_node(RefreshNodeCallback* callback) {
   const Row* row = NULL;
   ResultIterator rows(callback->result().get());
 
-  while (!found_host && rows.next()) {
-    row = rows.row();
-    if (callback->is_all_peers) {
+  if (callback->is_all_peers) {
+    while (!found_host && rows.next()) {
+      row = rows.row();
       if (settings_.address_factory->is_peer(row, connection_->host(), callback->address)) {
         found_host = true;
       }
-    } else {
-      found_host = true;
     }
+  } else if (rows.next()) {
+    row = rows.row();
+    found_host = true;
   }
 
   if (!found_host) {

--- a/src/request_processor.cpp
+++ b/src/request_processor.cpp
@@ -146,7 +146,7 @@ RequestProcessorSettings::RequestProcessorSettings()
     , max_tracing_wait_time_ms(CASS_DEFAULT_MAX_TRACING_DATA_WAIT_TIME_MS)
     , retry_tracing_wait_time_ms(CASS_DEFAULT_RETRY_TRACING_DATA_WAIT_TIME_MS)
     , tracing_consistency(CASS_DEFAULT_TRACING_CONSISTENCY)
-    , address_factory(new DefaultAddressFactory()) {
+    , address_factory(new AddressFactory()) {
   profiles.set_empty_key("");
 }
 

--- a/src/wkt.cpp
+++ b/src/wkt.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 
 #line 1 "wkt.rl"
 /*


### PR DESCRIPTION
When using SNI routing the driver is not mapping event address to the representation used by the driver (an `Address` with an IP and SNI name). It needs to be mapped using the `rpc_address` from the system tables.