### PR TITLE
Log instead of assert in order to avoid core dumps on shutdown

### DIFF
--- a/src/event_loop.cpp
+++ b/src/event_loop.cpp
@@ -61,7 +61,8 @@ EventLoop::~EventLoop() {
       uv_run(loop(), UV_RUN_DEFAULT);
       rc = uv_loop_close(loop());
       if (rc != 0) {
-        LOG_INFO("Event loop still has pending handles");
+        uv_print_all_handles(loop(), stderr);
+        LOG_ERROR("Event loop still has pending handles");
       }
     }
   }


### PR DESCRIPTION
Customer complained that core dumps from an unclean event loop were interfering with their regular evaluation of core dumps.  The code in question occurs at event loop shutdown so the extra handles shouldn't be much of a concern.