### PR TITLE
Non null values wont be read after a row with null value for the column

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -204,14 +204,13 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
   } else if (data_type->is_user_type()) {
     const UserType& user_type = static_cast<const UserType&>(*data_type);
     count_ = user_type.fields().size();
-  } else {
-    count_ = 0;
   }
 }
 
 bool Value::update(const Decoder& decoder) {
   decoder_ = decoder;
-  if (!decoder_.is_null()) {
+  is_null_ = decoder_.is_null();
+  if (!is_null_) {
     if (data_type_->is_collection()) {
       return decoder_.decode_int32(count_);
     } else if (data_type_->is_tuple()) {
@@ -223,9 +222,7 @@ bool Value::update(const Decoder& decoder) {
     }
   } else {
     count_ = 0;
-    is_null_ = true;
   }
-
   return true;
 }
 

--- a/tests/src/unit/tests/test_value.cpp
+++ b/tests/src/unit/tests/test_value.cpp
@@ -111,6 +111,30 @@ TEST(ValueUnitTest, BadDecimal) {
             CASS_ERROR_LIB_NOT_ENOUGH_DATA);
 }
 
+TEST(ValueUnitTest, NullInNextRow) {
+  DataType::ConstPtr data_type(new DataType(CASS_VALUE_TYPE_INT));
+
+  // Size (int32_t) and contents of element
+  const signed char input[8] = {0,  0,  0,  4,  0, 0, 0, 2};
+  Decoder decoder((const char*)input, 12);
+
+  // init with a non null column in a row
+  Value value(data_type, 2, decoder);
+  EXPECT_FALSE(value.is_null());
+
+  const signed char null_input[4] = {-1, 1, 1, 1};
+  Decoder null_decoder((const char*)null_input, 4);
+
+  // simulate next row null value in the column
+  null_decoder.update_value(value);
+  EXPECT_TRUE(value.is_null());
+
+  // next row non null value check is_null() returns correct value
+  Decoder decoder2((const char*)input, 12);
+  decoder2.update_value(value);
+  EXPECT_FALSE(value.is_null());
+}
+
 TEST(ValueUnitTest, NullElementInCollectionList) {
   const signed char input[12] = {
     -1, -1, -1, -1,            // Element 1 is NULL

--- a/tests/src/unit/tests/test_value.cpp
+++ b/tests/src/unit/tests/test_value.cpp
@@ -115,14 +115,14 @@ TEST(ValueUnitTest, NullInNextRow) {
   DataType::ConstPtr data_type(new DataType(CASS_VALUE_TYPE_INT));
 
   // Size (int32_t) and contents of element
-  const signed char input[8] = {0,  0,  0,  4,  0, 0, 0, 2};
+  const signed char input[8] = { 0, 0, 0, 4, 0, 0, 0, 2 };
   Decoder decoder((const char*)input, 12);
 
   // init with a non null column in a row
   Value value(data_type, 2, decoder);
   EXPECT_FALSE(value.is_null());
 
-  const signed char null_input[4] = {-1, 1, 1, 1};
+  const signed char null_input[4] = { -1, 1, 1, 1 };
   Decoder null_decoder((const char*)null_input, 4);
 
   // simulate next row null value in the column


### PR DESCRIPTION
`is_null_` was not correctly updated for the non null values on the next row read, added untittest that simulates the scenario
Also removed `else` branch in the `ctor` that was setting `count_` to zero, it is already set in ctor member initialiser list.
