### PR TITLE
Always stop reconnect timer in cluster

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -454,9 +454,10 @@ void Cluster::on_reconnect(ControlConnector* connector) {
 
 void Cluster::internal_close() {
   is_closing_ = true;
+  bool was_timer_running = timer_.is_running();
+  timer_.stop();
   monitor_reporting_timer_.stop();
-  if (timer_.is_running()) {
-    timer_.stop();
+  if (was_timer_running) {
     handle_close();
   } else if (reconnector_) {
     reconnector_->cancel();


### PR DESCRIPTION
It needs to be explicitly stopped so that the timer handle is cleaned up
before the event loop is closed.