### PR TITLE
Replace deprecated function for OpenSSL >= 3.0

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -91,7 +91,13 @@ static void ssl_log_errors(const char* context) {
   const char* data;
   int flags;
   int err;
-  while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+  while ((err =
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+              ERR_get_error_all(NULL, NULL, NULL, &data, &flags)
+#else
+              ERR_get_error_line_data(NULL, NULL, &data, &flags)
+#endif
+              ) != 0) {
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     LOG_ERROR("%s: %s:%s", context, buf, (flags & ERR_TXT_STRING) ? data : "");
@@ -104,7 +110,13 @@ static String ssl_error_string() {
   int flags;
   int err;
   String error;
-  while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+  while ((err =
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+              ERR_get_error_all(NULL, NULL, NULL, &data, &flags)
+#else
+              ERR_get_error_line_data(NULL, NULL, &data, &flags)
+#endif
+              ) != 0) {
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     if (!error.empty()) error.push_back(',');


### PR DESCRIPTION
ERR_get_error_line_data is deprecated in OpenSSL >= 3.0.
It can be replaced by the newer function ERR_get_error_all added in OpenSSL 3.0.