### PR TITLE
drop deprecated call with OpenSSL 3.0

### DIFF
--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -91,7 +91,11 @@ static void ssl_log_errors(const char* context) {
   const char* data;
   int flags;
   int err;
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  while ((err = ERR_get_error_all(NULL, NULL, NULL, &data, &flags)) != 0) {
+#else
   while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+#endif
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     LOG_ERROR("%s: %s:%s", context, buf, (flags & ERR_TXT_STRING) ? data : "");
@@ -104,7 +108,11 @@ static String ssl_error_string() {
   int flags;
   int err;
   String error;
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  while ((err = ERR_get_error_all(NULL, NULL, NULL, &data, &flags)) != 0) {
+#else
   while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
+#endif
     char buf[256];
     ERR_error_string_n(err, buf, sizeof(buf));
     if (!error.empty()) error.push_back(',');


### PR DESCRIPTION
This make build fails on Fedora >= 36 and RHEL / CentOS 9

```
[ 99%] Building CXX object src/CMakeFiles/cassandra.dir/gssapi/dse_auth_gssapi.cpp.o
cd /builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/x86_64-redhat-linux-gnu/src && /usr/bin/g++ -DCASS_BUILDING -Dcassandra_EXPORTS -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/gssapi -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/curl -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/hdr_histogram -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/http-parser -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/minizip -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/mt19937_64 -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/rapidjson/rapidjson -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/third_party/sparsehash/src -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/include -I/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64-v2 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wno-implicit-fallthrough  -std=c++11 -Wall -pedantic -Wextra -Wno-long-long -Wno-unused-parameter -Wno-variadic-macros -Wno-unused-local-typedefs -Werror -fPIC -MD -MT src/CMakeFiles/cassandra.dir/gssapi/dse_auth_gssapi.cpp.o -MF CMakeFiles/cassandra.dir/gssapi/dse_auth_gssapi.cpp.o.d -o CMakeFiles/cassandra.dir/gssapi/dse_auth_gssapi.cpp.o -c /builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/gssapi/dse_auth_gssapi.cpp
/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp: In function 'void ssl_log_errors(const char*)':
/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp:94:40: error: 'long unsigned int ERR_get_error_line_data(const char**, int*, const char**, int*)' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
   94 |   while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/openssl/engine.h:31,
                 from /builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp:25:
/usr/include/openssl/err.h:413:15: note: declared here
  413 | unsigned long ERR_get_error_line_data(const char **file, int *line,
      |               ^~~~~~~~~~~~~~~~~~~~~~~
/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp: In function 'datastax::String ssl_error_string()':
/builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp:107:40: error: 'long unsigned int ERR_get_error_line_data(const char**, int*, const char**, int*)' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
  107 |   while ((err = ERR_get_error_line_data(NULL, NULL, &data, &flags)) != 0) {
      |                 ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/openssl/engine.h:31,
                 from /builddir/build/BUILD/cpp-driver-698a1b01801ddf150d9f8793faa8548877f5f7f5/src/ssl/ssl_openssl_impl.cpp:25:
/usr/include/openssl/err.h:413:15: note: declared here
  413 | unsigned long ERR_get_error_line_data(const char **file, int *line,
      |               ^~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors

```