### PR TITLE
Value::update performance enhancement & simplification

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -210,18 +210,8 @@ Value::Value(const DataType::ConstPtr& data_type, Decoder decoder)
 bool Value::update(const Decoder& decoder) {
   decoder_ = decoder;
   is_null_ = decoder_.is_null();
-  if (!is_null_) {
-    if (data_type_->is_collection()) {
+  if (!is_null_ && data_type_->is_collection()) {
       return decoder_.decode_int32(count_);
-    } else if (data_type_->is_tuple()) {
-      const CompositeType& composite_type = static_cast<const CompositeType&>(*data_type_);
-      count_ = composite_type.types().size();
-    } else if (data_type_->is_user_type()) {
-      const UserType& user_type = static_cast<const UserType&>(*data_type_);
-      count_ = user_type.fields().size();
-    }
-  } else {
-    count_ = 0;
   }
   return true;
 }

--- a/src/value.hpp
+++ b/src/value.hpp
@@ -103,26 +103,22 @@ public:
   bool is_null() const { return is_null_; }
 
   bool is_collection() const {
-    if (!data_type_) return false;
-    return data_type_->is_collection();
+    return data_type_ && data_type_->is_collection();
   }
 
   bool is_map() const {
-    if (!data_type_) return false;
-    return data_type_->is_map();
+    return data_type_ && data_type_->is_map();
   }
 
   bool is_tuple() const {
-    if (!data_type_) return false;
-    return data_type_->is_tuple();
+    return data_type_ && data_type_->is_tuple();
   }
 
   bool is_user_type() const {
-    if (!data_type_) return false;
-    return data_type_->is_user_type();
+    return data_type_ && data_type_->is_user_type();
   }
 
-  int32_t count() const { return count_; }
+  int32_t count() const { return count_ * is_null_; }
 
   StringRef to_string_ref() const {
     if (is_null()) return StringRef();


### PR DESCRIPTION
There is no point updating the `count_` in the `Value::update()` for types other than collection type.
This change saves another 15% ish in `cass_iterator_next`

<img width="1184" alt="Screenshot 2021-11-20 at 16 44 40" src="https://user-images.githubusercontent.com/2941615/142734315-a58aedda-2c4e-4da1-aa7a-6020f874fa67.png">

<img width="1189" alt="Screenshot 2021-11-20 at 16 45 31" src="https://user-images.githubusercontent.com/2941615/142734371-c01ad88d-8424-49db-82da-27e0866a1780.png">


