### PR TITLE
CPP-953 Naive attempt to avoid pure virtual function calls at cluster shutdown

### DIFF
--- a/src/prepare_host_handler.cpp
+++ b/src/prepare_host_handler.cpp
@@ -67,8 +67,6 @@ void PrepareHostHandler::prepare(uv_loop_t* loop, const ConnectionSettings& sett
 }
 
 void PrepareHostHandler::on_close(Connection* connection) {
-  callback_(this);
-
   dec_ref(); // The event loop is done with this handler
 }
 


### PR DESCRIPTION
Attempt to avoid entangling PrepareHostHandler and Cluster by avoiding executing host up checks when closing the handler