### PR TITLE
Allow users to request TLS client-side enforcement

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -629,6 +629,12 @@ typedef enum CassSslVerifyFlags_ {
   CASS_SSL_VERIFY_PEER_IDENTITY_DNS = 0x04
 } CassSslVerifyFlags;
 
+typedef enum CassSslTlsVersion_ {
+  CASS_SSL_VERSION_TLS1   = 0x00,
+  CASS_SSL_VERSION_TLS1_1 = 0x01,
+  CASS_SSL_VERSION_TLS1_2 = 0x02,
+} CassSslTlsVersion;
+
 typedef enum CassProtocolVersion_ {
   CASS_PROTOCOL_VERSION_V1    = 0x01, /**< Deprecated */
   CASS_PROTOCOL_VERSION_V2    = 0x02, /**< Deprecated */
@@ -4686,6 +4692,20 @@ cass_ssl_set_private_key_n(CassSsl* ssl,
                            size_t key_length,
                            const char* password,
                            size_t password_length);
+
+/**
+ * Set minimum supported client-side protocol version. This will prevent the
+ * connection using protocol versions earlier than the specified one. Useful
+ * for preventing TLS downgrade attacks.
+ *
+ * @public @memberof CassSsl
+ *
+ * @param[in] ssl
+ * @param[in] min_version
+ * @return CASS_OK if successful, otherwise an error occurred.
+ */
+CASS_EXPORT CassError
+cass_ssl_set_min_protocol_version(CassSsl* ssl, CassSslTlsVersion min_version);
 
 /***********************************************************************************
  *

--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -632,7 +632,7 @@ typedef enum CassSslVerifyFlags_ {
 typedef enum CassSslTlsVersion_ {
   CASS_SSL_VERSION_TLS1   = 0x00,
   CASS_SSL_VERSION_TLS1_1 = 0x01,
-  CASS_SSL_VERSION_TLS1_2 = 0x02,
+  CASS_SSL_VERSION_TLS1_2 = 0x02
 } CassSslTlsVersion;
 
 typedef enum CassProtocolVersion_ {

--- a/src/ssl.cpp
+++ b/src/ssl.cpp
@@ -65,6 +65,10 @@ CassError cass_ssl_set_private_key_n(CassSsl* ssl, const char* key, size_t key_l
   return ssl->set_private_key(key, key_length, password, password_length);
 }
 
+CassError cass_ssl_set_min_protocol_version(CassSsl* ssl, CassSslTlsVersion min_version) {
+  return ssl->set_min_protocol_version(min_version);
+}
+
 } // extern "C"
 
 template <class T>

--- a/src/ssl.hpp
+++ b/src/ssl.hpp
@@ -87,6 +87,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length) = 0;
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length) = 0;
+  virtual CassError set_min_protocol_version(CassSslTlsVersion min_version) = 0;
 
 protected:
   int verify_flags_;

--- a/src/ssl/ssl_no_impl.cpp
+++ b/src/ssl/ssl_no_impl.cpp
@@ -44,4 +44,8 @@ CassError NoSslContext::set_private_key(const char* key, size_t key_length, cons
   return CASS_ERROR_LIB_NOT_IMPLEMENTED;
 }
 
+CassError NoSslContext::set_min_protocol_version(CassSslTlsVersion min_version) {
+  return CASS_ERROR_LIB_NOT_IMPLEMENTED;
+}
+
 SslContext::Ptr NoSslContextFactory::create() { return SslContext::Ptr(new NoSslContext()); }

--- a/src/ssl/ssl_no_impl.hpp
+++ b/src/ssl/ssl_no_impl.hpp
@@ -40,6 +40,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length);
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length);
+  virtual CassError set_min_protocol_version(CassSslTlsVersion min_version);
 };
 
 class NoSslContextFactory : public SslContextFactoryBase<NoSslContextFactory> {

--- a/src/ssl/ssl_openssl_impl.cpp
+++ b/src/ssl/ssl_openssl_impl.cpp
@@ -41,12 +41,14 @@
     !defined(LIBRESSL_VERSION_NUMBER) // Required as OPENSSL_VERSION_NUMBER for LibreSSL is defined
                                       // as 2.0.0
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#define SSL_CAN_SET_MIN_VERSION
 #define SSL_CLIENT_METHOD TLS_client_method
 #else
 #define SSL_CLIENT_METHOD SSLv23_client_method
 #endif
 #else
 #if (LIBRESSL_VERSION_NUMBER >= 0x20302000L)
+#define SSL_CAN_SET_MIN_VERSION
 #define SSL_CLIENT_METHOD TLS_client_method
 #else
 #define SSL_CLIENT_METHOD SSLv23_client_method
@@ -609,6 +611,48 @@ CassError OpenSslContext::set_private_key(const char* key, size_t key_length, co
   EVP_PKEY_free(pkey);
 
   return CASS_OK;
+}
+
+CassError OpenSslContext::set_min_protocol_version(CassSslTlsVersion min_version) {
+#ifdef SSL_CAN_SET_MIN_VERSION
+  int method;
+  switch (min_version) {
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1:
+      method = TLS1_VERSION;
+      break;
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_1:
+      method = TLS1_1_VERSION;
+      break;
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_2:
+      method = TLS1_2_VERSION;
+      break;
+    default:
+      // unsupported version
+      return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  SSL_CTX_set_min_proto_version(ssl_ctx_, method);
+  return CASS_OK;
+#else
+  // If we don't have the `set_min_proto_version` function then we do this via
+  // the (deprecated in later versions) options function.
+  int options = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3;
+  switch (min_version) {
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1:
+      break;
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_1:
+      options |= SSL_OP_NO_TLSv1;
+      break;
+    case CassSslTlsVersion::CASS_SSL_VERSION_TLS1_2:
+      options |= SSL_OP_NO_TLSv1;
+      options |= SSL_OP_NO_TLSv1_1;
+      break;
+    default:
+      // unsupported version
+      return CASS_ERROR_LIB_BAD_PARAMS;
+  }
+  SSL_CTX_set_options(ssl_ctx_, options);
+  return CASS_OK;
+#endif
 }
 
 SslContext::Ptr OpenSslContextFactory::create() { return SslContext::Ptr(new OpenSslContext()); }

--- a/src/ssl/ssl_openssl_impl.hpp
+++ b/src/ssl/ssl_openssl_impl.hpp
@@ -61,6 +61,7 @@ public:
   virtual CassError set_cert(const char* cert, size_t cert_length);
   virtual CassError set_private_key(const char* key, size_t key_length, const char* password,
                                     size_t password_length);
+  virtual CassError set_min_protocol_version(CassSslTlsVersion min_version);
 
 private:
   SSL_CTX* ssl_ctx_;


### PR DESCRIPTION
This change allows users of the driver to request that the TLS version is at least a specified minimum. This helps to avoid [downgrade attacks](https://www.praetorian.com/blog/man-in-the-middle-tls-ssl-protocol-downgrade-attack/), such as [POODLE](https://en.wikipedia.org/wiki/POODLE).

In practice I'll always be wanting to call this to enforce TLS1.2, but I thought it made sense to make it optional, and to allow users to say which TLS version they care about so that the driver remains fully back-compatible and flexible.