### PR TITLE
Reduce address comparisons for network topology replica calculation

### DIFF
--- a/src/host.hpp
+++ b/src/host.hpp
@@ -304,4 +304,24 @@ bool remove_host(CopyOnWriteHostVec& hosts, const Address& address);
 
 }}} // namespace datastax::internal::core
 
+
+namespace std {
+
+#if defined(HASH_IN_TR1) && !defined(_WIN32)
+namespace tr1 {
+#endif
+
+template <>
+struct hash<datastax::internal::core::Host*> {
+  size_t operator()(const datastax::internal::core::Host* host) const {
+    return host->address().hash_code();
+  }
+};
+
+#if defined(HASH_IN_TR1) && !defined(_WIN32)
+} // namespace tr1
+#endif
+
+} // namespace std
+
 #endif

--- a/tests/src/unit/tests/test_token_map.cpp
+++ b/tests/src/unit/tests/test_token_map.cpp
@@ -129,12 +129,12 @@ TEST(TokenMapUnitTest, Murmur3MultipleTokensPerHost) {
 TEST(TokenMapUnitTest, Murmur3LargeNumberOfVnodes) {
   TestTokenMap<Murmur3Partitioner> test_murmur3;
 
-  size_t num_dcs = 3;
-  size_t num_racks = 3;
-  size_t num_hosts = 4;
+  size_t num_dcs = 2;
+  size_t num_racks = 1;
+  size_t num_hosts = 27;
   size_t num_vnodes = 256;
-  size_t replication_factor = 3;
-  size_t total_replicas = std::min(num_hosts, replication_factor) * num_dcs;
+  size_t replication_factor = 54;
+  size_t total_replicas = replication_factor;
 
   ReplicationMap replication;
   MT19937_64 rng;
@@ -166,9 +166,13 @@ TEST(TokenMapUnitTest, Murmur3LargeNumberOfVnodes) {
     }
   }
 
+  printf("Populating token map finished finished\n");
+
   // Build token map
   add_keyspace_network_topology("ks1", replication, token_map);
+  printf("Building replicas\n");
   token_map->build();
+  printf("Building replicas finished\n");
 
   const String keys[] = { "test", "abc", "def", "a", "b", "c", "d" };
 


### PR DESCRIPTION
This uses a `DenseHashSet` to keep prevent duplicate replicas instead of doing a linear scan through the existing replicas. I'm seeing around a 4.5x speed up for larger replication factors (rf = 54).