### PR TITLE
Adapt MemoryOrder definition for C++ 20

### DIFF
--- a/src/atomic/atomic_std.hpp
+++ b/src/atomic/atomic_std.hpp
@@ -22,12 +22,12 @@
 namespace datastax { namespace internal {
 
 enum MemoryOrder {
-  MEMORY_ORDER_RELAXED = std::memory_order_relaxed,
-  MEMORY_ORDER_CONSUME = std::memory_order_consume,
-  MEMORY_ORDER_ACQUIRE = std::memory_order_acquire,
-  MEMORY_ORDER_RELEASE = std::memory_order_release,
-  MEMORY_ORDER_ACQ_REL = std::memory_order_acq_rel,
-  MEMORY_ORDER_SEQ_CST = std::memory_order_seq_cst
+  MEMORY_ORDER_RELAXED = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_relaxed),
+  MEMORY_ORDER_CONSUME = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_consume),
+  MEMORY_ORDER_ACQUIRE = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_acquire),
+  MEMORY_ORDER_RELEASE = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_release),
+  MEMORY_ORDER_ACQ_REL = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_acq_rel),
+  MEMORY_ORDER_SEQ_CST = static_cast<std::underlying_type<std::memory_order>::type>(std::memory_order_seq_cst)
 };
 
 template <class T>


### PR DESCRIPTION
When compiling the code with C++ 20 the following error message is produced:

    enumerator value for ‘MEMORY_ORDER_RELAXED’ must have integral or unscoped enumeration type

This is because with C++ 20 the type of those values changed to an enum class. The `static_cast` extracts the numeric values so they can be used here as before.