### PR TITLE
Fix signed/unsigned mismatch

### DIFF
--- a/src/string_ref.cpp
+++ b/src/string_ref.cpp
@@ -18,6 +18,6 @@
 
 namespace datastax {
 
-const StringRef::size_type StringRef::npos = -1;
+const StringRef::size_type StringRef::npos = std::numeric_limits<StringRef::size_type>::max();
 
 } // namespace datastax

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -179,7 +179,7 @@ void set_thread_name(const String& thread_name) {
   THREADNAME_INFO info;
   info.dwType = 0x1000;
   info.szName = thread_name.c_str();
-  info.dwThreadID = -1;
+  info.dwThreadID = (DWORD)-1;
   info.dwFlags = 0;
 #pragma warning(push)
 #pragma warning(disable : 6320 6322)


### PR DESCRIPTION
This fixes the following warnings from MSVC:

    warning C4245: 'initializing': conversion from 'int' to 'datastax::StringRef::size_type', signed/unsigned mismatch
    warning C4245: '=': conversion from 'int' to 'DWORD', signed/unsigned mismatch