### PR TITLE
Prioritize ${OPENSSL_ROOT_DIR} over system paths

### DIFF
--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -82,8 +82,8 @@ if (WIN32)
   unset(_programfiles)
 else ()
   set(_OPENSSL_ROOT_HINTS
-    /usr/local/opt/openssl
     ${OPENSSL_ROOT_DIR}
+    /usr/local/opt/openssl
     ENV OPENSSL_ROOT_DIR
     )
 endif ()


### PR DESCRIPTION
This commit reorders the locations where CMake will look for openssl, starting with ${OPENSSL_ROOT_DIR} and then proceeding to system install locations.

This allows the user to provide a different Openssl version with -DOPENSSL_ROOT_DIR=<path/to/openssl>