### PR TITLE
CPP-975: remove special handling for 4.0 in ExecutionProfileTest.Inte…

### DIFF
--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -307,9 +307,6 @@ CASSANDRA_INTEGRATION_TEST_F(ExecutionProfileTest, Consistency) {
     cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version();
   }
   std::string expected_message = "SERIAL is not supported as conditional update commit consistency";
-  if (cass_version >= "4.0.0") {
-    expected_message = "You must use conditional updates for serializable writes";
-  }
   ASSERT_TRUE(contains(result.error_message(), expected_message));
 
   // Execute a simple query with assigned profile (should fail)


### PR DESCRIPTION
…gration_Cassandra_Consistency as the error message is consistent with earlier C* versions