### PR TITLE
CPP-966 Compilation warnings after cass_set_use_hostname_resolution() marked as deprecated

### DIFF
--- a/tests/src/integration/ccm/bridge.cpp
+++ b/tests/src/integration/ccm/bridge.cpp
@@ -1491,7 +1491,7 @@ CCM::Bridge::generate_create_updateconf_command(CassVersion cassandra_version) {
     updateconf_command.push_back("enable_scripted_user_defined_functions:true");
   }
 
-  if (cassandra_version >= "4.0.0") {
+  if (cassandra_version >= "4.0.0" && !is_dse()) {
     updateconf_command.push_back("enable_materialized_views:true");
     updateconf_command.push_back("enable_user_defined_functions:true");
   }

--- a/tests/src/integration/integration.cpp
+++ b/tests/src/integration/integration.cpp
@@ -65,7 +65,6 @@ Integration::Integration()
     , is_session_requested_(true)
     , is_keyspace_change_requested_(true)
     , is_test_chaotic_(false)
-    , is_beta_protocol_(Options::is_beta_protocol())
     , protocol_version_(CASS_PROTOCOL_VERSION_V4)
     , create_keyspace_query_("")
     , start_time_(0ull) {

--- a/tests/src/integration/integration.hpp
+++ b/tests/src/integration/integration.hpp
@@ -344,13 +344,6 @@ protected:
    */
   bool is_test_chaotic_;
   /**
-   * Flag to indicate if the beta protocol should be enabled. True if beta
-   * protocol should be enabled (Cassandra must be >= v3.10.0); false
-   * otherwise.
-   * (DEFAULT: true)
-   */
-  bool is_beta_protocol_;
-  /**
    * Workload to apply to the cluster
    */
   std::vector<CCM::DseWorkload> dse_workload_;

--- a/tests/src/integration/integration.hpp
+++ b/tests/src/integration/integration.hpp
@@ -79,13 +79,17 @@
     return;                 \
   }
 
-#define SKIP_TEST_MESSAGE(server_version_string, comparison, version_string)                     \
+#define SERVER_VERSION_SKIP_TEST_MESSAGE(server_version_string, comparison, version_string)                     \
   "Unsupported for Apache Cassandra Version " << server_version_string << ": Server version is " \
   << comparison << " the specified version " << version_string
 
+#define PROTOCOL_VERSION_SKIP_TEST_MESSAGE(server_version_string, comparison, version_string)                     \
+  "Unsupported for Apache Cassandra protocol version " << server_version_string << ": Server version is " \
+  << comparison << " the specified protocol version " << version_string
+
 /* Maintain existing behaviour; default message indicates server < specified */
 #define SKIP_TEST_VERSION(server_version_string, version_string)           \
-  SKIP_TEST(SKIP_TEST_MESSAGE(server_version_string, '<', version_string))
+  SKIP_TEST(SERVER_VERSION_SKIP_TEST_MESSAGE(server_version_string, '<', version_string))
 
 #define CHECK_VERSION(version)                                                      \
   do {                                                                              \
@@ -114,25 +118,27 @@
     if (!Options::is_cassandra()) {                                                 \
       cass_version = static_cast<CCM::DseVersion>(cass_version).get_cass_version(); \
     }                                                                               \
-    std::vector<std::string> versions = Utils::explode(version_string,',');        \
+    std::vector<std::string> versions = Utils::explode(version_string,',');         \
     for (unsigned int i = 0; i < versions.size(); i++) {                            \
       CCM::CassVersion version = CCM::CassVersion(versions[i]);                     \
       if (cass_version.major_version == version.major_version &&                    \
           cass_version.minor_version == version.minor_version &&                    \
           cass_version.patch_version >= version.patch_version) {                    \
         SKIP_TEST(                                                                  \
-          SKIP_TEST_MESSAGE(                                                        \
+          SERVER_VERSION_SKIP_TEST_MESSAGE(                                         \
             cass_version.to_string(), ">=", version.to_string()))                   \
       }                                                                             \
     }                                                                               \
   } while (0)
 
-#define CHECK_PROTOCOL_VERSION(version)                          \
-  do {                                                           \
-    int proto_version = this->protocol_version_;                 \
-    if (proto_version < version) {                   \
-      SKIP_TEST_VERSION(std::to_string(proto_version), #version) \
-    }                                                            \
+#define CHECK_PROTOCOL_VERSION(version)            \
+  do {                                             \
+    int proto_version = this->protocol_version_;   \
+    if (proto_version < version) {                 \
+      SKIP_TEST(                                   \
+        PROTOCOL_VERSION_SKIP_TEST_MESSAGE(        \
+          proto_version, '<', version));           \
+    }                                              \
   } while (0)
 
 #define CHECK_OPTIONS_VERSION(version)                                 \

--- a/tests/src/integration/objects/cluster.hpp
+++ b/tests/src/integration/objects/cluster.hpp
@@ -207,22 +207,6 @@ public:
   }
 
   /**
-   * Enable/Disable the use of hostname resolution
-   *
-   * This is useful for authentication (Kerberos) or encryption (SSL)
-   * services that require a valid hostname for verification.
-   *
-   * @param enable True if hostname resolution should be enabled; false
-   *               otherwise (default: true)
-   * @return Cluster object
-   */
-  Cluster& with_hostname_resolution(bool enable = true) {
-    EXPECT_EQ(CASS_OK, cass_cluster_set_use_hostname_resolution(
-                           get(), (enable == true ? cass_true : cass_false)));
-    return *this;
-  }
-
-  /**
    * Sets the number of I/O threads. This is the number of threads that will
    * handle query requests
    *

--- a/tests/src/integration/objects/cluster.hpp
+++ b/tests/src/integration/objects/cluster.hpp
@@ -81,19 +81,6 @@ public:
   }
 
   /**
-   * Use the newest beta protocol version
-   *
-   * @param enable True if beta protocol should be enable; false the highest
-   *               non-beta protocol will be used (unless set) (default: false)
-   * @return Cluster object
-   */
-  Cluster& with_beta_protocol(bool enable = false) {
-    EXPECT_EQ(CASS_OK, cass_cluster_set_use_beta_protocol_version(
-                           get(), (enable == true ? cass_true : cass_false)));
-    return *this;
-  }
-
-  /**
    * Sets the timeout for connecting to a node
    *
    * @param timeout_ms Connect timeout in milliseconds

--- a/tests/src/integration/options.cpp
+++ b/tests/src/integration/options.cpp
@@ -48,7 +48,6 @@ std::string Options::public_key_ = "public.key";
 std::string Options::private_key_ = "private.key";
 bool Options::is_verbose_ccm_ = false;
 bool Options::is_verbose_integration_ = false;
-bool Options::is_beta_protocol_ = false;
 
 // Static initialization is not guaranteed for the following types
 CCM::DseCredentialsType Options::dse_credentials_type_;
@@ -185,8 +184,6 @@ bool Options::initialize(int argc, char* argv[]) {
           is_verbose_ccm_ = true;
           is_verbose_integration_ = true;
         }
-      } else if (key == "--disable-beta-protocol") {
-        is_beta_protocol_ = false;
       }
 #ifdef CASS_USE_LIBSSH2
       else if (key == "--authentication") {
@@ -380,11 +377,6 @@ void Options::print_help() {
   std::cout << "  --verbose(=ccm,integration)" << std::endl
             << "      "
             << "Enable verbose output for component(s)." << std::endl;
-  std::cout << "  --disable-beta-protocol" << std::endl
-            << "      "
-            << "Disable beta protocol use by default." << std::endl
-            << "      "
-            << "NOTE: Individual tests may override this setting." << std::endl;
   std::cout << std::endl;
 }
 
@@ -521,8 +513,6 @@ SharedPtr<CCM::Bridge, StdDeleter<CCM::Bridge> > Options::ccm() {
 bool Options::is_verbose_ccm() { return is_verbose_ccm_; }
 
 bool Options::is_verbose_integration() { return is_verbose_integration_; }
-
-bool Options::is_beta_protocol() { return is_beta_protocol_; }
 
 Options::Options() {}
 

--- a/tests/src/integration/options.hpp
+++ b/tests/src/integration/options.hpp
@@ -227,13 +227,6 @@ public:
    */
   static bool is_verbose_integration();
   /**
-   * Flag to determine if beta protocol should be enabled or not; should only
-   * pertain to the default setting.
-   *
-   * @return True if beta protocol should be enabled; false otherwise
-   */
-  static bool is_beta_protocol();
-  /**
    * Get a CCM instance based on the options
    *
    * @return CCM instance
@@ -350,13 +343,6 @@ private:
    * Flag to determine if verbose integration output should enabled
    */
   static bool is_verbose_integration_;
-  /**
-   * Flag to determine if beta protocol should be enabled or not; should only
-   * pertain to the default setting.
-   *
-   * NOTE: Individual tests can still override this.
-   */
-  static bool is_beta_protocol_;
 
   /**
    * Hidden default constructor

--- a/tests/src/integration/tests/test_auth.cpp
+++ b/tests/src/integration/tests/test_auth.cpp
@@ -34,7 +34,7 @@ public:
     // Configure and start the CCM cluster for plain text authentication usage
     ccm_->update_cluster_configuration("authenticator", "PasswordAuthenticator");
     ccm_->start_cluster("-Dcassandra.superuser_setup_delay_ms=0");
-    cluster_ = default_cluster().with_beta_protocol(false);
+    cluster_ = default_cluster();
   }
 
 protected:

--- a/tests/src/integration/tests/test_dse_auth.cpp
+++ b/tests/src/integration/tests/test_dse_auth.cpp
@@ -177,7 +177,6 @@ protected:
     Cluster cluster = dse::Cluster::build()
                           .with_gssapi_authenticator("dse", principal)
                           .with_contact_points(contact_points_)
-                          .with_hostname_resolution(true)
                           .with_schema_metadata(false);
     Session session = cluster.connect();
 
@@ -203,7 +202,6 @@ protected:
     Cluster cluster = dse::Cluster::build()
                           .with_plaintext_authenticator(username, password)
                           .with_contact_points(contact_points_)
-                          .with_hostname_resolution(true)
                           .with_schema_metadata(false);
     Session session = cluster.connect();
 

--- a/tests/src/integration/tests/test_exec_profile.cpp
+++ b/tests/src/integration/tests/test_exec_profile.cpp
@@ -30,7 +30,6 @@ public:
       , skip_base_execution_profile_(false) {
     replication_factor_ = 2;
     number_dc1_nodes_ = 2;
-    is_beta_protocol_ = false; // Issue with beta protocol v5 and functions on Cassandra v3.10.0+
   }
 
   void SetUp() {

--- a/tests/src/integration/tests/test_prepared_metadata.cpp
+++ b/tests/src/integration/tests/test_prepared_metadata.cpp
@@ -70,7 +70,6 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterDoesntUpdateColumnCount
 
   // Ensure beta protocol is not set
   Session session = default_cluster()
-                        .with_beta_protocol(false)
                         .with_protocol_version(CASS_PROTOCOL_VERSION_V4)
                         .connect(keyspace_name_);
 
@@ -87,10 +86,10 @@ CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterDoesntUpdateColumnCount
  */
 CASSANDRA_INTEGRATION_TEST_F(PreparedMetadataTests, AlterProperlyUpdatesColumnCount) {
   CHECK_FAILURE;
-  CHECK_VERSION(4.0.0);
+  CHECK_PROTOCOL_VERSION(CASS_PROTOCOL_VERSION_V5);
 
   // Ensure protocol v5 or greater
-  Session session = default_cluster().with_beta_protocol(true).connect(keyspace_name_);
+  Session session = default_cluster().connect(keyspace_name_);
 
   // The column count will properly update after the alter
   prepared_check_column_count_after_alter(session, 3u);

--- a/tests/src/integration/tests/test_set_keyspace.cpp
+++ b/tests/src/integration/tests/test_set_keyspace.cpp
@@ -156,7 +156,6 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, QueryNotSupported) {
   CHECK_FAILURE;
 
   Session session = default_cluster()
-                        .with_beta_protocol(false)
                         .with_protocol_version(CASS_PROTOCOL_VERSION_V4)
                         .connect();
 
@@ -216,7 +215,6 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, PreparedNotSupported) {
   CHECK_FAILURE;
 
   Session session = default_cluster()
-                        .with_beta_protocol(false)
                         .with_protocol_version(CASS_PROTOCOL_VERSION_V4)
                         .connect();
 
@@ -362,7 +360,6 @@ CASSANDRA_INTEGRATION_TEST_F(SetKeyspaceTests, BatchNotSupported) {
   CHECK_FAILURE;
 
   Session session = default_cluster()
-                        .with_beta_protocol(false)
                         .with_protocol_version(CASS_PROTOCOL_VERSION_V4)
                         .connect();
 


### PR DESCRIPTION
Along with some other miscellaneous fixes as well:

* Remove beta protocol support from the CLI options to the integration test as well as the test cluster itself
* Clean up some error messages