### PR TITLE
CPP-993 Build failures due to std::underlying_type

### DIFF
--- a/src/atomic/atomic_std.hpp
+++ b/src/atomic/atomic_std.hpp
@@ -18,6 +18,7 @@
 #define DATASTAX_INTERNAL_ATOMIC_STD_HPP
 
 #include <atomic>
+#include <type_traits>
 
 namespace datastax { namespace internal {
 


### PR DESCRIPTION
Add type_traits include.  PR #533 used std::underlying_type to make the MemoryOrder enum work with C++ 20 but apparently some older gcc instance still want the type_traits include that defines the underlying_type template.