### PR TITLE
Update default libuv version to fix Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -489,7 +489,7 @@ pipeline {
                       Run only the tests whose name matches one of the positive patterns but none of the negative patterns. <b>\'?\'</b> matches any single character; <b>\'*\'</b> matches any substring; <b>\':\'</b> separates two patterns.''')
     string(
       name: 'LIBUV_VERSION',
-      defaultValue: '1.34.0',
+      defaultValue: '1.38.0',
       description: '''<p>libuv version to build and use</p>
                       <b>Note:</b> Rarely does this need to change.''')
     choice(


### PR DESCRIPTION
A recent rebuild of the Jenkins runners upgraded our Rocky8 runner from 8.8 to 8.9.  This apparently brought with it a new version of cmake which fails to build with the following error:

```
[2024-04-17T17:09:55.769Z] cmake: symbol lookup error: cmake: undefined symbol: uv_fs_get_system_error
```

Function in question is [present](https://docs.libuv.org/en/v1.x/fs.html#c.uv_fs_get_system_error) as of libuv 1.38.0 so my guess is that the new version of cmake leverages functions in the newer libuv that aren't present in the libuv version we were using as a default.

To confirm I ran a test build with LIBUV_VERSION set to 1.38.0 and the build was completely green.