### PR TITLE
Remove centos7 and add Cassandra 5.0-beta1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -406,9 +406,9 @@ pipeline {
     choice(
       name: 'ADHOC_BUILD_AND_EXECUTE_TESTS_SERVER_VERSION',
       choices: [
-                '3.0',      // Previous Apache Cassandra
                 '3.11',     // Current Apache Cassandra
-                '4.0',      // Development Apache Cassandra
+                '4.0',      // Current Apache Cassandra
+                '5.0-beta1',      // Current Apache Cassandra
                 'dse-5.1.35',  // Legacy DataStax Enterprise
                 'dse-6.8.30',  // Development DataStax Enterprise
                 'ALL'],
@@ -421,16 +421,16 @@ pipeline {
                           <th align="left">Description</th>
                         </tr>
                         <tr>
-                          <td><strong>3.0</strong></td>
-                          <td>Apache Cassandra&reg; v3.0.x</td>
-                        </tr>
-                        <tr>
                           <td><strong>3.11</strong></td>
                           <td>Apache Cassandra&reg; v3.11.x</td>
                         </tr>
                         <tr>
                           <td><strong>4.0</strong></td>
-                          <td>Apache Cassandra&reg; v4.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                          <td>Apache Cassandra&reg; v4.x</td>
+                        </tr>
+                        <tr>
+                          <td><strong>5.0-beta1</strong></td>
+                          <td>Apache Cassandra&reg; v5.0-beta1 (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
                         </tr>
                         <tr>
                           <td><strong>dse-5.1</strong></td>
@@ -438,13 +438,12 @@ pipeline {
                         </tr>
                         <tr>
                           <td><strong>dse-6.8</strong></td>
-                          <td>DataStax Enterprise v6.8.x (<b>CURRENTLY UNDER DEVELOPMENT</b>)</td>
+                          <td>DataStax Enterprise v6.8.x</td>
                         </tr>
                       </table>''')
     choice(
       name: 'OS_VERSION',
-      choices: ['centos/7-64/cpp',
-                'rocky/8-64/cpp',
+      choices: ['rocky/8-64/cpp',
                 'rocky/9-64/cpp',
                 'ubuntu/bionic64/cpp',
                 'ubuntu/focal64/cpp',
@@ -456,10 +455,6 @@ pipeline {
                         <tr>
                           <th align="left">Choice</th>
                           <th align="left">Description</th>
-                        </tr>
-                        <tr>
-                          <td><strong>centos/7-64/cpp</strong></td>
-                          <td>CentOS 7 x86_64</td>
                         </tr>
                         <tr>
                           <td><strong>rocky/8-64/cpp</strong></td>
@@ -525,8 +520,7 @@ pipeline {
         axes {
           axis {
             name 'OS_VERSION'
-            values 'centos/7-64/cpp',
-                   'rocky/8-64/cpp',
+            values 'rocky/8-64/cpp',
                    'rocky/9-64/cpp',
                    'ubuntu/bionic64/cpp',
                    'ubuntu/focal64/cpp',
@@ -650,8 +644,7 @@ pipeline {
         axes {
           axis {
             name 'OS_VERSION'
-            values 'centos/7-64/cpp',
-                   'rocky/8-64/cpp',
+            values 'rocky/8-64/cpp',
                    'rocky/9-64/cpp',
                    'ubuntu/bionic64/cpp',
                    'ubuntu/focal64/cpp',
@@ -728,9 +721,9 @@ pipeline {
         axes {
           axis {
             name 'SERVER_VERSION'
-            values '3.0',      // Previous Apache Cassandra
-                   '3.11',     // Current Apache Cassandra
-                   '4.0',      // Development Apache Cassandra
+            values '3.11',     // Current Apache Cassandra
+                   '4.0',      // Current Apache Cassandra
+                   '5.0-beta1',   // Development Apache Cassandra
                    'dse-5.1.35',  // Legacy DataStax Enterprise
                    'dse-6.8.30'   // Development DataStax Enterprise
           }


### PR DESCRIPTION
Removed CentOS7 because it's EOL.

Currently tests are failing and I think most (if not all) are related to cassandra.yml setting renaming that happened in C* 4.1. This is happening with other drivers as well. The Java driver already handled this in https://github.com/apache/cassandra-java-driver/pull/1924

C* 4.1 renamed some config settings but C* is still looking at the old names because of backwards compability reasons. However, C* fails to launch if it finds both the NEW name and the OLD name for a specific setting. The driver tests call ccm to add the OLD config setting but because the name is different from the one in cassadra.yml, the setting is added to cassandra.yml instead of replacing it.

I've already updated the AMI so it's already running the updated ccm that supports 5.0.

Note that you need to manually trigger the integration tests on jenkins, they don't run by default on the per-commit build.