### PR TITLE
CPP-998 cass_cluster_set_load_balance_dc_aware_n() fails with NULL/empty local DC

### DIFF
--- a/include/cassandra.h
+++ b/include/cassandra.h
@@ -2139,6 +2139,10 @@ cass_cluster_set_load_balance_round_robin(CassCluster* cluster);
  * For each query, all live nodes in a primary 'local' DC are tried first,
  * followed by any node from other DCs.
  *
+ * <b>Important:</b> Pass in NULL for local_dc to automatically use the data center of the first
+ * connected control connection host as the primary data center. This approach is recommended
+ * over manually selecting the local_dc.
+ *
  * <b>Note:</b> This is the default, and does not need to be called unless
  * switching an existing from another policy or changing settings.
  * Without further configuration, a default local_dc is chosen from the
@@ -2154,7 +2158,7 @@ cass_cluster_set_load_balance_round_robin(CassCluster* cluster);
  * @public @memberof CassCluster
  *
  * @param[in] cluster
- * @param[in] local_dc The primary data center to try first
+ * @param[in] local_dc The primary data center to try first, or NULL to use the DC of the first connected node
  * @param[in] used_hosts_per_remote_dc The number of hosts used in each remote
  * DC if no hosts are available in the local dc (<b>deprecated</b>)
  * @param[in] allow_remote_dcs_for_local_cl Allows remote hosts to be used if no
@@ -2173,6 +2177,10 @@ cass_cluster_set_load_balance_dc_aware(CassCluster* cluster,
  * Same as cass_cluster_set_load_balance_dc_aware(), but with lengths for string
  * parameters.
  *
+ * <b>Important:</b> If local_dc is NULL or local_dc_length is 0, the data center of 
+ * the first connected control connection host will be automatically used as the 
+ * primary data center. This approach is recommended over manually selecting the local_dc.
+ *
  * @deprecated The remote DC settings for DC-aware are not suitable for most
  * scenarios that require DC failover. There is also unhandled gap between
  * replication factor number of nodes failing and the full cluster failing. Only
@@ -2181,11 +2189,11 @@ cass_cluster_set_load_balance_dc_aware(CassCluster* cluster,
  * @public @memberof CassCluster
  *
  * @param[in] cluster
- * @param[in] local_dc
- * @param[in] local_dc_length
+ * @param[in] local_dc Primary data center to try first, or NULL to use the DC of the first connected node
+ * @param[in] local_dc_length Length of local_dc string
  * @param[in] used_hosts_per_remote_dc (<b>deprecated</b>)
  * @param[in] allow_remote_dcs_for_local_cl (<b>deprecated</b>)
- * @return same as cass_cluster_set_load_balance_dc_aware()
+ * @return CASS_OK if successful, otherwise an error occurred
  *
  * @see cass_cluster_set_load_balance_dc_aware()
  */

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -281,8 +281,8 @@ void cass_cluster_set_load_balance_round_robin(CassCluster* cluster) {
 CassError cass_cluster_set_load_balance_dc_aware(CassCluster* cluster, const char* local_dc,
                                                  unsigned used_hosts_per_remote_dc,
                                                  cass_bool_t allow_remote_dcs_for_local_cl) {
-  // Allow NULL local_dc to use the DC of the first connected node
-  if (local_dc == NULL) {
+  // Allow NULL or empty local_dc to use the DC of the first connected node
+  if (local_dc == NULL || *local_dc == '\0') {
     return cass_cluster_set_load_balance_dc_aware_n(cluster, NULL, 0,
                                                     used_hosts_per_remote_dc,
                                                     allow_remote_dcs_for_local_cl);

--- a/src/cluster_config.cpp
+++ b/src/cluster_config.cpp
@@ -281,8 +281,11 @@ void cass_cluster_set_load_balance_round_robin(CassCluster* cluster) {
 CassError cass_cluster_set_load_balance_dc_aware(CassCluster* cluster, const char* local_dc,
                                                  unsigned used_hosts_per_remote_dc,
                                                  cass_bool_t allow_remote_dcs_for_local_cl) {
+  // Allow NULL local_dc to use the DC of the first connected node
   if (local_dc == NULL) {
-    return CASS_ERROR_LIB_BAD_PARAMS;
+    return cass_cluster_set_load_balance_dc_aware_n(cluster, NULL, 0,
+                                                    used_hosts_per_remote_dc,
+                                                    allow_remote_dcs_for_local_cl);
   }
   return cass_cluster_set_load_balance_dc_aware_n(cluster, local_dc, SAFE_STRLEN(local_dc),
                                                   used_hosts_per_remote_dc,
@@ -293,11 +296,13 @@ CassError cass_cluster_set_load_balance_dc_aware_n(CassCluster* cluster, const c
                                                    size_t local_dc_length,
                                                    unsigned used_hosts_per_remote_dc,
                                                    cass_bool_t allow_remote_dcs_for_local_cl) {
-  if (local_dc == NULL || local_dc_length == 0) {
-    return CASS_ERROR_LIB_BAD_PARAMS;
-  }
+  // If local_dc is NULL or length is 0, we use an empty string which causes the driver
+  // to use the DC of the first connected node
+  String dc_name = (local_dc != NULL && local_dc_length > 0) ? 
+                    String(local_dc, local_dc_length) : String();
+  
   cluster->config().set_load_balancing_policy(new DCAwarePolicy(
-      String(local_dc, local_dc_length), used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
+      dc_name, used_hosts_per_remote_dc, !allow_remote_dcs_for_local_cl));
   return CASS_OK;
 }
 

--- a/tests/src/integration/tests/test_cluster.cpp
+++ b/tests/src/integration/tests/test_cluster.cpp
@@ -26,11 +26,11 @@ public:
  *
  * @jira_ticket CPP-368
  * @test_category configuration
- * @expected_result Error out because it is illegal to specify a null local-dc.
+ * @expected_result Success because NULL local-dc now means use the DC of the first connected node.
  */
 CASSANDRA_INTEGRATION_TEST_F(ClusterTests, SetLoadBalanceDcAwareNullLocalDc) {
   test::driver::Cluster cluster;
-  EXPECT_EQ(CASS_ERROR_LIB_BAD_PARAMS,
+  EXPECT_EQ(CASS_OK,
             cass_cluster_set_load_balance_dc_aware(cluster.get(), NULL, 99, cass_false));
 }
 

--- a/tests/src/integration/tests/test_cluster.cpp
+++ b/tests/src/integration/tests/test_cluster.cpp
@@ -22,16 +22,26 @@ public:
 };
 
 /**
- * Set local dc to null for dc-aware lbp
+ * Set local dc to null or empty for dc-aware lbp
  *
  * @jira_ticket CPP-368
  * @test_category configuration
- * @expected_result Success because NULL local-dc now means use the DC of the first connected node.
+ * @expected_result Success because NULL or empty local-dc now means use the DC of the first connected node.
  */
-CASSANDRA_INTEGRATION_TEST_F(ClusterTests, SetLoadBalanceDcAwareNullLocalDc) {
-  test::driver::Cluster cluster;
-  EXPECT_EQ(CASS_OK,
-            cass_cluster_set_load_balance_dc_aware(cluster.get(), NULL, 99, cass_false));
+CASSANDRA_INTEGRATION_TEST_F(ClusterTests, SetLoadBalanceDcAwareNullOrEmptyLocalDc) {
+  // Test with NULL local_dc
+  {
+    test::driver::Cluster cluster;
+    EXPECT_EQ(CASS_OK,
+              cass_cluster_set_load_balance_dc_aware(cluster.get(), NULL, 99, cass_false));
+  }
+  
+  // Test with empty string local_dc
+  {
+    test::driver::Cluster cluster;
+    EXPECT_EQ(CASS_OK,
+              cass_cluster_set_load_balance_dc_aware(cluster.get(), "", 99, cass_false));
+  }
 }
 
 /**


### PR DESCRIPTION
As a nice self-contained issue I thought this might be an interesting test case to see how Claude Code might handle this change.  The basic change was identified pretty readily (which is impressive even in a constrained case like this) but the inconsistent behaviour between functions was a bit surprising to me.