### PR TITLE
Bump minimum required version for cmake4 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(cassandra C CXX)
 
 set(CASS_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/appveyor.ps1
+++ b/appveyor.ps1
@@ -331,7 +331,7 @@ Function Install-Driver-Environment {
     Push-Location -Path "$($dependencies_build_location_prefix)/libuv"
 
     $cmakelists_contents = @"
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(libuv)
 set(PROJECT_DISPLAY_NAME "AppVeyor CI Build for libuv")
 set(PROJECT_MODULE_DIR $cmake_modules_dir)
@@ -380,7 +380,7 @@ add_dependencies(`${PROJECT_NAME} `${LIBUV_LIBRARY_NAME})
       Push-Location -Path "$($dependencies_build_location_prefix)/openssl/$_"
 
       $cmakelists_contents = @"
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(OpenSSL)
 set(PROJECT_DISPLAY_NAME "AppVeyor CI Build for OpenSSL")
 set(PROJECT_MODULE_DIR $cmake_modules_dir)
@@ -432,7 +432,7 @@ add_dependencies(`${PROJECT_NAME} `${OPENSSL_LIBRARY_NAME})
     Push-Location -Path "$($dependencies_build_location_prefix)/zlib"
 
     $cmakelists_contents = @"
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(zlib)
 set(PROJECT_DISPLAY_NAME "AppVeyor CI Build for zlib")
 set(PROJECT_MODULE_DIR $cmake_modules_dir)
@@ -508,7 +508,7 @@ add_dependencies(`${PROJECT_NAME} `${ZLIB_LIBRARY_NAME})
     Push-Location -Path "$($dependencies_build_location_prefix)/libssh2"
 
     $cmakelists_contents = @"
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(libssh2)
 set(PROJECT_DISPLAY_NAME "AppVeyor CI Build for libssh2")
 set(PROJECT_MODULE_DIR $cmake_modules_dir)

--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,7 +1,7 @@
 #
 # Format and verify formatting using clang-format
 #
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 include(FindPackageHandleStandardArgs)
 

--- a/cmake/ExternalProject-OpenSSL.cmake
+++ b/cmake/ExternalProject-OpenSSL.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 if(NOT MSVC_ENVIRONMENT_SCRIPT)

--- a/cmake/ExternalProject-libssh2.cmake
+++ b/cmake/ExternalProject-libssh2.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/cmake/ExternalProject-libuv.cmake
+++ b/cmake/ExternalProject-libuv.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/cmake/ExternalProject-zlib.cmake
+++ b/cmake/ExternalProject-zlib.cmake
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 include(ExternalProject)
 include(Windows-Environment)
 

--- a/examples/async/CMakeLists.txt
+++ b/examples/async/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME async)

--- a/examples/auth/CMakeLists.txt
+++ b/examples/auth/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME auth)

--- a/examples/basic/CMakeLists.txt
+++ b/examples/basic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME basic)

--- a/examples/batch/CMakeLists.txt
+++ b/examples/batch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME batch)

--- a/examples/bind_by_name/CMakeLists.txt
+++ b/examples/bind_by_name/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME bind_by_name)

--- a/examples/callbacks/CMakeLists.txt
+++ b/examples/callbacks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME callbacks)

--- a/examples/cloud/CMakeLists.txt
+++ b/examples/cloud/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME cloud)

--- a/examples/collections/CMakeLists.txt
+++ b/examples/collections/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME collections)

--- a/examples/concurrent_executions/CMakeLists.txt
+++ b/examples/concurrent_executions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME concurrent_executions)

--- a/examples/date_time/CMakeLists.txt
+++ b/examples/date_time/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME date_time)

--- a/examples/dse/date_range/CMakeLists.txt
+++ b/examples/dse/date_range/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME date_range)

--- a/examples/dse/geotypes/CMakeLists.txt
+++ b/examples/dse/geotypes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME geotypes)

--- a/examples/dse/gssapi/CMakeLists.txt
+++ b/examples/dse/gssapi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 

--- a/examples/dse/plaintext/CMakeLists.txt
+++ b/examples/dse/plaintext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 

--- a/examples/dse/proxy_execution/CMakeLists.txt
+++ b/examples/dse/proxy_execution/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME proxy_execution)

--- a/examples/duration/CMakeLists.txt
+++ b/examples/duration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME duration)

--- a/examples/execution_profiles/CMakeLists.txt
+++ b/examples/execution_profiles/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME execution_profiles)

--- a/examples/host_listener/CMakeLists.txt
+++ b/examples/host_listener/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME host_listener)

--- a/examples/logging/CMakeLists.txt
+++ b/examples/logging/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME logging)

--- a/examples/maps/CMakeLists.txt
+++ b/examples/maps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME maps)

--- a/examples/named_parameters/CMakeLists.txt
+++ b/examples/named_parameters/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME named_parameters)

--- a/examples/paging/CMakeLists.txt
+++ b/examples/paging/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME paging)

--- a/examples/perf/CMakeLists.txt
+++ b/examples/perf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME perf)

--- a/examples/prepared/CMakeLists.txt
+++ b/examples/prepared/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME prepared)

--- a/examples/schema_meta/CMakeLists.txt
+++ b/examples/schema_meta/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME schema_meta)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME simple)

--- a/examples/ssl/CMakeLists.txt
+++ b/examples/ssl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME ssl)

--- a/examples/tracing/CMakeLists.txt
+++ b/examples/tracing/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME tracing)

--- a/examples/tuple/CMakeLists.txt
+++ b/examples/tuple/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME tuple)

--- a/examples/udt/CMakeLists.txt
+++ b/examples/udt/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME udt)

--- a/examples/uuids/CMakeLists.txt
+++ b/examples/uuids/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ".")
 set(PROJECT_EXAMPLE_NAME uuids)

--- a/src/third_party/sparsehash/CMakeLists.txt
+++ b/src/third_party/sparsehash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 include(CheckCXXSourceCompiles)
 include(CheckFunctionExists)

--- a/topics/building/README.md
+++ b/topics/building/README.md
@@ -24,7 +24,7 @@ __NOTE__: The build procedures only need to be performed for driver development
 
 The C/C++ driver depends on the following software:
 
-* [CMake] v2.8.12+
+* [CMake] v3.10+
 * [libuv] 1.x
 * Kerberos v5 ([Heimdal] or [MIT]) \*
 * [OpenSSL] v1.0.x, v1.1.x or v3.x \*\*


### PR DESCRIPTION
CMake 4, released half a year ago, [has dropped compatibility with versions older than 3.5](https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features).

This patch bumps the minimal required version of CMake to 3.10.

I've set it to 3.10, so it doesn’t get deprecated as soon as 3.5 will be, and yet doesn’t impose a too new CMake release to build. For reference, [the oldest maintained LTS debian already has 3.18](https://packages.debian.org/bullseye/cmake).

This issue has come up on [nixpkgs](https://nixos.org), where a migration to CMake 4 is underway.

See also:
- NixOS/nixpkgs/issues/445447
- https://github.com/NixOS/nixpkgs/pull/475601