### PR TITLE
Post donation doc updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,34 +4,28 @@ This is a guide to help you get started contributing to the DataStax C/C++ Drive
 
 ## Forking and Branching
 
-Fork the driver on [GitHub](https://github.com/datastax/cpp-driver/) and clone
+Fork the driver on [GitHub](https://github.com/apache/cassandra-cpp-driver) and clone
 your fork locally.
 
 ```bash
-$ git clone https://github.com/username/cpp-driver.git
-$ cd cpp-driver
-$ git remote add upstream https://github.com/datastax/cpp-driver.git
+$ git clone https://github.com/username/cassandra-cpp-driver.git
+$ cd cassandra-cpp-driver
+$ git remote add upstream https://github.com/apache/cassandra-cpp-driver
 ```
-
-Bug fixes should be applied directly to the stable version branch and
-features should go to the unstable branch (this will likely be 'master' going
-forward).
 
 Features that require breaking API or ABI changes should be reserved for major
 releases and will probably not be considered for minor or patch releases.
 For features and big changes consider using a feature branch.
 
 ```bash
-$ git checkout -b awesome-new-feature -t origin/1.0
+$ git checkout -b awesome-new-feature
 ```
-
-(where '1.0' is the latest stable branch)
 
 Make sure to `git rebase` to keep your branch up-to-date.
 
 ```bash
 $ git fetch upstream
-$ git rebase upstream/1.0
+$ git rebase upstream
 ```
 
 To avoid duplication of work it's important to check [JIRA] to see if a bug
@@ -122,15 +116,15 @@ your branch and create a pull request.
 $ git push origin awesome-new-feature
 ```
 
-Go to your fork (http://github.com/username/cpp-driver), select the branch with
+Go to your fork (https://github.com/username/cassandra-cpp-driver), select the branch with
 your changes and click 'Pull Request'. Fill out the pull request and submit.
 
 Your changes should usually be reviewed within a few days, otherwise we'll try
 to give you a timeline. If your pull request requires fixes or changes please
-submit them in a new commit. These commits will be squashed before inclusion
-into the stable or unstable branches.
+submit them in a new commit. These commits will be squashed before your pull request
+is merged.
 
-[JIRA]: https://datastax-oss.atlassian.net/browse/CPP/?selectedTab=com.atlassian.jira.jira-projects-plugin:summary-panel
+[JIRA]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20CASSCPP%20ORDER%20BY%20key%20DESC
 [Google C++ Style Guide]: https://google.github.io/styleguide/cppguide.html
 [early exits]: http://llvm.org/docs/CodingStandards.html#use-early-exits-and-continue-to-simplify-code
 [testing guide]: https://docs.datastax.com/en/developer/cpp-driver/latest/topics/testing

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A modern, feature-rich and highly tunable C/C++ client library for
 Cassandra Query Language v3. This driver can also be used with other DataStax
 products:
 
-* [DataStax Enterprise]
+* DataStax Enterprise (DSE)
 * [DataStax Astra]
 
 ## Getting the Driver
@@ -15,7 +15,6 @@ the driver (for multiple operating systems and multiple architectures) can be
 obtained from our [Artifactory server].  Binaries are available for the following
 operating systems:
 
-* CentOS 7
 * Rocky Linux 8.8
 * Rocky Linux 9.2
 * Ubuntu 20.04
@@ -29,27 +28,8 @@ The driver depends on the following libraries:
 * zlib
 
 The version of OpenSSL and zlib provided with each Linux distribution above can be used
-to build the driver.  A version of libuv > 1.x is provided for CentOS 7 and Rocky
-Linux; this can be found under the `dependencies` directory for each platform.
-Packages for all three dependencies are provided for Windows distributions.
-
-## Upgrading for DSE
-
-Starting with Apache Cassandra C/C++ Driver v2.15.0, DataStax
-Enterprise (DSE) support is now available; using the DSE driver exclusively is no
-longer required for DSE customers.
-
-### For DSE driver users
-
-Linking changes will be required when migrating to this driver. Replace `-ldse` with `-lcassandra`.
-
-### For Cassandra driver users
-
-No changes will be required when upgrading to this driver. There will be new
-driver dependencies when using any of the binary versions obtained from our
-[Artifactory server] as [Kerberos] is utilized in the [DSE features] of this
-driver. See the [installation] section for more information on obtaining the
-dependencies for a specific platform.
+to build the driver.  A version of libuv > 1.x is provided for Rocky Linux under the
+`dependencies` directory.  Packages for all three dependencies are provided for Windows distributions.
 
 ## Features
 
@@ -101,7 +81,6 @@ Both 32-bit (x86) and 64-bit (x64) architectures are supported
 
 We build and test the driver on the following platforms:
 
-* CentOS 7 w/ gcc 4.8.5
 * Rocky Linux 8.8 w/ gcc 8.5.0
 * Rocky Linux 9.2 w/ gcc 11.3.1
 * Ubuntu 20.04 w/ gcc 9.4.0
@@ -122,8 +101,8 @@ __Disclaimer__: DataStax products do not support big-endian systems.
 
 ## Getting Help
 
-* JIRA: [jira]
-* Mailing List: [mailing list]
+* Quality bug reports are welcome at the [CASSCPP project] of the ASF JIRA
+* You can talk about the driver, ask questions and get help in the #cassandra-drivers channel on [ASF Slack]
 
 ## Examples
 
@@ -206,22 +185,18 @@ int main(int argc, char* argv[]) {
 }
 ```
 
-## Links
-
-[Apache Cassandra®]: http://cassandra.apache.org
-[DataStax Enterprise]: http://www.datastax.com/products/datastax-enterprise
-[Examples]: examples/
-[Artifactory server]: https://datastax.jfrog.io/artifactory/cpp-php-drivers/cpp-driver/builds
-[GitHub]: https://github.com/datastax/cpp-driver
-[cpp-driver-compatability-matrix]: https://docs.datastax.com/en/driver-matrix/docs/cpp-drivers.html
-[Home]: http://docs.datastax.com/en/developer/cpp-driver/latest
 [API]: http://docs.datastax.com/en/developer/cpp-driver/latest/api
-[Getting Started]: http://docs.datastax.com/en/developer/cpp-driver/latest/topics
+[ASF Slack]: https://the-asf.slack.com/
+[Apache Cassandra®]: http://cassandra.apache.org
+[Artifactory server]: https://datastax.jfrog.io/artifactory/cpp-php-drivers/cpp-driver/builds
 [Building]: http://docs.datastax.com/en/developer/cpp-driver/latest/topics/building
-[jira]: https://datastax-oss.atlassian.net/browse/CPP
-[mailing list]: https://groups.google.com/a/lists.datastax.com/forum/#!forum/cpp-driver-user
+[CASSCPP project]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20CASSCPP%20ORDER%20BY%20key%20DESC
+[cpp-driver-compatability-matrix]: https://docs.datastax.com/en/driver-matrix/docs/cpp-drivers.html
 [DataStax Astra]: https://astra.datastax.com
-[Kerberos]: https://web.mit.edu/kerberos
+[Examples]: examples/
+[Getting Started]: http://docs.datastax.com/en/developer/cpp-driver/latest/topics
+[GitHub]: https://github.com/apache/cassandra-cpp-driver
+[Home]: http://docs.datastax.com/en/developer/cpp-driver/latest
 
 [Asynchronous API]: https://docs.datastax.com/en/developer/cpp-driver/latest/topics/#futures
 [Simple]: https://docs.datastax.com/en/developer/cpp-driver/latest/topics/#executing-queries
@@ -252,4 +227,3 @@ int main(int argc, char* argv[]) {
 [DSE Proxy Authentication]: http://docs.datastax.com/en/developer/cpp-driver/latest/dse_features/authentication/#proxy-authentication
 [DSE Proxy Execution]: http://docs.datastax.com/en/developer/cpp-driver/latest/dse_features/authentication/#proxy-execution
 [DSE DateRange]: https://github.com/datastax/cpp-driver/blob/master/examples/dse/date_range/date_range.c
-[DSE features]: http://docs.datastax.com/en/developer/cpp-driver/latest/dse_features

--- a/topics/README.md
+++ b/topics/README.md
@@ -8,7 +8,6 @@ All packages referenced below can be found on our [Artifactory server].
 
 Packages are available for the following platforms:
 
-* CentOS 7
 * Rocky Linux 8.8
 * Rocky Linux 9.2
 * Ubuntu 20.04
@@ -246,7 +245,8 @@ without incurring extra allocations.
 ## TODO
 
 Here are some features that are missing from the C/C++ driver, but are included
-with other drivers. The schedule for these features can be found on [JIRA].
+with other drivers. The schedule for these features can be found on the
+[CASSCPP project] of the ASF JIRA.
 
 - Compression
 - Schema event registration and notification
@@ -264,4 +264,4 @@ with other drivers. The schedule for these features can be found on [JIRA].
 [`CassIterator`]: https://docs.datastax.com/en/developer/cpp-driver/latest/api/struct.CassIterator/
 [`CassSession`]: https://docs.datastax.com/en/developer/cpp-driver/latest/api/struct.CassSession/
 [post]: http://www.datastax.com/dev/blog/4-simple-rules-when-using-the-datastax-drivers-for-cassandra
-[JIRA]: https://datastax-oss.atlassian.net/browse/CPP
+[CASSCPP project]: https://issues.apache.org/jira/issues/?jql=project%20%3D%20CASSCPP%20ORDER%20BY%20key%20DESC

--- a/topics/building/README.md
+++ b/topics/building/README.md
@@ -4,7 +4,6 @@ The DataStax C/C++ Driver for Apache Cassandra and DataStax Products will build
 on most standard Unix-like and Microsoft Windows platforms. Packages are
 available for the following platforms:
 
-* CentOS 7
 * Rocky Linux 8.8
 * Rocky Linux 9.2
 * Ubuntu 20.04
@@ -51,9 +50,9 @@ OpenSSL 3.x by default and the unit and integration tests all pass on these plat
 
 ## Linux/Mac OS
 
-The driver is known to build on CentOS/RHEL 6/7/8, Mac OS X 10.10/10.11 (Yosemite
+The driver is known to build on Rocky Linux 8/9, Mac OS X 10.10/10.11 (Yosemite
 and El Capitan), Mac OS 10.12/10.13 (Sierra and High Sierra), and Ubuntu
-14.04/16.04/18.04 LTS.
+20.04/22.04 LTS.
 
 __NOTE__: The driver will also build on most standard Unix-like systems using
           GCC 4.1.2+ or Clang 3.4+.
@@ -62,7 +61,7 @@ __NOTE__: The driver will also build on most standard Unix-like systems using
 
 #### Initial environment setup
 
-##### CentOS/RHEL (Yum)
+##### Rocky/RHEL (Yum)
 
 ```bash
 yum install automake cmake gcc-c++ git libtool
@@ -89,7 +88,7 @@ brew install autoconf automake cmake libtool
 
 #### Kerberos
 
-##### CentOS/RHEL (Yum)
+##### Rocky/RHEL (Yum)
 
 ```bash
 yum install krb5-devel
@@ -105,14 +104,14 @@ apt-get install libkrb5-dev
 
 libuv v1.x should be used in order to ensure all features of the C/C++ driver
 are available. When using a package manager for your operating system make sure
-you install v1.x; if available.
+you install v1.x.
 
-##### CentOS, Rocky and Ubuntu packages
+##### Rocky and Ubuntu packages
 
 Packages are available from our [Artifactory server].  Select the driver version,
 build and platform and then look for the `dependencies` directory.  Note that the
-version of libuv available on Ubuntu can be used when building the driver.  As a
-result we only provide packages for CentOS and Rocky.
+version of libuv available on supported versions of Ubuntu can be used when
+building the driver.  As a result we only provide packages for Rocky Linux only.
 
 ##### Mac OS (Brew)
 
@@ -139,7 +138,7 @@ popd
 
 #### OpenSSL
 
-##### CentOS (Yum)
+##### Rocky (Yum)
 
 ```bash
 yum install openssl-devel
@@ -180,7 +179,7 @@ popd
 
 #### zlib
 
-##### CentOS (Yum)
+##### Rocky (Yum)
 
 ```bash
 yum install zlib-devel

--- a/topics/installation/README.md
+++ b/topics/installation/README.md
@@ -2,38 +2,8 @@
 
 ## Packages
 
-Pre-built packages are available for CentOS 7, Ubuntu 20.04/22.04,
-Rocky Linux 8 and 9 and Windows.  All packages are available from our
-[Artifactory server].
-
-### CentOS
-
-CentOS doesn't have up-to-date versions of libuv so we provide current packages.
-These packages can be found in the `dependencies` directory under each driver
-version in Artifactory.
-
-First install dependencies:
-
-```bash
-yum install openssl krb5 zlib
-rpm -Uvh libuv-<version>.rpm
-```
-
-Note: Replace `<version>` with the release version of the package.
-
-Then install the runtime library:
-
-```bash
-rpm -Uvh cassandra-cpp-driver-<version>.rpm
-```
-
-When developing against the driver you'll also want to install the development
-package and the debug symbols.
-
-```bash
-rpm -Uvh cassandra-cpp-driver-devel-<version>.rpm
-rpm -Uvh cassandra-cpp-driver-debuginfo-<version>.rpm
-```
+Pre-built packages are available for Ubuntu 20.04/22.04, Rocky Linux 8 and 9 and Windows.
+All packages are available from our [Artifactory server].
 
 ### Rocky Linux
 


### PR DESCRIPTION
In essence a version of [this PR](https://github.com/apache/cassandra-python-driver/pull/1262) for the CPP driver.  Updating links to point to ASF JIRA, removing references to the old Google Group and pointing people at ASF Slack... that kind of thing.

I also made a conscious effort to remove any references to CentOS generally (but specifically CentOS 7) in the relevant docs.  We ended support for CentOS when they moved to the stream model (see [this PR](https://github.com/apache/cassandra-cpp-driver/pull/566) and [this ticket](https://datastax-oss.atlassian.net/browse/CPP-1001) for more info).  We still have CentOS 7 artifacts for older releases in the Artifactory server but I felt like keeping the refs around would be more confusing than just removing them.

On the topic of that Artifactory server... we need to find some way to get off of that and onto a more sane way to manage dependencies.