### PR TITLE
CASSCPP-3 Crash on Pure virtual function while the destructor of the Session object is called

### DIFF
--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -663,6 +663,19 @@ void Cluster::notify_or_record(const ClusterEvent& event) {
   }
 }
 
+// TODO: This function takes a callback because it's called from both the host up and host add handlers.
+// The usage there is to send appropriate notifications to all other nodes whether query prep succeeds or
+// not.  But that processing isn't really part of what _this_ function is trying to accomplish; that
+// responsibility really relies with the host up or host add handler itself.
+//
+// A more robust implementation would be to implement the host up and host add handlers as a combined
+// sequence of ops and then wait on that whole sequence to either complete or fail.  That's a fairly
+// significant change to the current impl, though, so for now just moving the notifications into
+// the host up/add handlers will be sufficient.
+//
+// Why does any of this matter?  Originally we were triggering this callback on socket close even when
+// we were closing a connection.  This link has already been severed (see CASSCPP-3) but that effort
+// exposed the unnecessary entanglement described above.
 bool Cluster::prepare_host(const Host::Ptr& host, const PrepareHostHandler::Callback& callback) {
   if (connection_ && settings_.prepare_on_up_or_add_host) {
     PrepareHostHandler::Ptr prepare_host_handler(

--- a/src/connection.hpp
+++ b/src/connection.hpp
@@ -87,7 +87,7 @@ public:
    *
    * @param connection The closing connection.
    */
-  virtual void on_close(Connection* connection) = 0;
+  virtual void on_close(Connection* connection) {}
 };
 
 /**

--- a/src/prepare_host_handler.cpp
+++ b/src/prepare_host_handler.cpp
@@ -69,8 +69,6 @@ void PrepareHostHandler::prepare(uv_loop_t* loop, const ConnectionSettings& sett
 }
 
 void PrepareHostHandler::on_close(Connection* connection) {
-  callback_(this);
-
   dec_ref(); // The event loop is done with this handler
 }
 


### PR DESCRIPTION
Multiple steps to try to keep us out of the crash situation.  First: remove the call to the callback from the handler's on_close() function.  It's not especially useful when a connection is in the process of closing down like this; when that happens host up or host add events (the objective of the callback in question) should be considered unreliable anyway.  This change alone is _probably_ enough to fix the problem but it's effect there is entirely one of timing; by not having to handle the extra event delivery logic we're not taking as long in the callback so there's less opportunity to overlap with other resources being destructed.  That said, minimizing the amount of work here is still a pretty good idea.

Second: don't make the on_close() function of the handler a pure virtual function.  There's no obvious reason this function has to be a _pure_ virtual function so the hope is that by giving it a (no-op) body we'll just execute that if we wind up with a conversion from a PrepareHostHandler to a ConnectionListener object while the event loop is shutting down.
