### PR TITLE
CASSCPP-2 Support Clang variants (including AppleClang) for cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
       set(CASS_USE_STD_ATOMIC ON)
     endif()
   endif()
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
   # Version determined from: http://clang.llvm.org/cxx_status.html
   # 3.2 includes the full C++11 memory model, but 3.1 had atomic
   # support.
@@ -161,7 +161,7 @@ endif()
 # Top-level compiler flags
 #------------------------
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$" OR
    "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # Enable C++11 support to use std::atomic
   if(CASS_USE_STD_ATOMIC)
@@ -177,7 +177,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
     endif()
   endif()
 
-  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") 
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
     # Clang/Intel specific compiler options
     # I disabled long-long warning because boost generates about 50 such warnings
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra -Wno-long-long -Wno-unused-parameter")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ if(WIN32)
   endif()
 endif()
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconversion -Wno-sign-conversion -Wno-shorten-64-to-32 -Wno-undefined-var-template -Werror")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-int-float-conversion")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # To many superfluous warnings generated with GCC when using -Wconversion (see: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=40752)


### PR DESCRIPTION
With [CMake 3.0](https://cmake.org/cmake/help/latest/policy/CMP0025.html), `AppleClang` is now a separate compiler target which needs to be explicitly accounted for to allow the driver to easily be built on Mac, and as per further discussion with Brett, we've decided to allow [all clang variants here](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html#variable:CMAKE_%3CLANG%3E_COMPILER_ID) using `"${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang$"`, and if any of them end up having any unfortunate issues with flag compatibility, we can deal with them on a case-by-case basis

Build succeeds on
```
Apple clang version 17.0.0 (clang-1700.0.13.5)
Target: arm64-apple-darwin24.6.0
````