### PR TITLE
CASSCPP-13 Update DRIVER_NAME after donation to ASF

### DIFF
--- a/src/driver_info.cpp
+++ b/src/driver_info.cpp
@@ -29,7 +29,7 @@
 namespace datastax { namespace internal {
 
 const char* driver_name() {
-  return "DataStax C/C++ Driver for Apache Cassandra and DataStax Products";
+  return "Apache Cassandra C/C++ Driver";
 }
 
 const char* driver_version() {


### PR DESCRIPTION
Update to match what we've done with the Java and Python drivers.

Confirmed via local testing.  Jenkins run against this change was clean as well.